### PR TITLE
Enable demo fallback and pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy marketing war command center
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        env:
+          VITE_BASE_PATH: ./
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,73 +1,49 @@
-# Welcome to your Lovable project
+# Marketing War Command Center
 
-## Project info
+The Marketing War Command Center is a Vite + React 18 control surface for orchestrating Twilio-powered marketing operations. It
+shows live build telemetry from Supabase, houses configuration flows for Twilio/Flex, and is paired with a Supabase Edge
+function layer plus a Rust desktop companion.
 
-**URL**: https://lovable.dev/projects/b400fb8a-c720-4082-93db-49b744cf5b54
+## Local development
 
-## How can I edit this code?
-
-There are several ways of editing your application.
-
-**Use Lovable**
-
-Simply visit the [Lovable Project](https://lovable.dev/projects/b400fb8a-c720-4082-93db-49b744cf5b54) and start prompting.
-
-Changes made via Lovable will be committed automatically to this repo.
-
-**Use your preferred IDE**
-
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
-
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
-
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
+```bash
+npm install
 npm run dev
 ```
 
-**Edit a file directly in GitHub**
+The dev server listens on `http://localhost:8080` by default. Tailwind, shadcn UI, and React Fast Refresh are all prewired.
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
+### Environment variables
 
-**Use GitHub Codespaces**
+The dashboard automatically falls back to curated demo data when Supabase credentials are missing, keeping the UI interactive.
+Provide the following variables in a `.env.local` file to light up realtime telemetry:
 
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
+```bash
+VITE_SUPABASE_URL="https://<your-project>.supabase.co"
+VITE_SUPABASE_ANON_KEY="<anon-key>"
+```
 
-## What technologies are used for this project?
+The Supabase schema, triggers, and edge functions live in [`supabase/`](supabase/README.md). Deploy them with the Supabase CLI
+before pointing CI to the `report-build` endpoint.
 
-This project is built with:
+## Production deployment
 
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
+This repository now includes an automated GitHub Pages workflow (`.github/workflows/deploy.yml`). Once GitHub Pages is enabled
+for the repository:
 
-## How can I deploy this project?
+1. Go to **Settings → Pages** and choose **GitHub Actions** as the source.
+2. Merge to `main` (or trigger the workflow manually). The action builds the Vite site and publishes it to Pages.
+3. The workflow outputs a ready-to-share URL (e.g., `https://<org>.github.io/<repo>/`) so stakeholders can click and test the UI
+   immediately.
 
-Simply open [Lovable](https://lovable.dev/projects/b400fb8a-c720-4082-93db-49b744cf5b54) and click on Share -> Publish.
+Assets are built with a relative base path, so the site works on both GitHub Pages and custom domains without further
+configuration. If you host elsewhere, set `VITE_BASE_PATH` to the appropriate subdirectory before running `npm run build`.
 
-## Can I connect a custom domain to my Lovable project?
+## Quality checklist
 
-Yes, you can!
+- **Supabase**: `supabase db push`, `supabase functions deploy report-build`, `supabase functions deploy twilio-build-alert`.
+- **Frontend**: `npm run lint`, `npm run build`.
+- **Desktop companion**: build the Rust project in `desktop-companion/` for deep Twilio runtime introspection.
+- **Twilio credentials**: store secrets via `supabase secrets set` as outlined in `supabase/README.md`.
 
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+Keeping these guardrails in place ensures the command center stays error-proof, self-healing, and production ready.

--- a/docs/twilio-launch-runbook.md
+++ b/docs/twilio-launch-runbook.md
@@ -1,0 +1,64 @@
+# Twilio Marketing Platform Launch Runbook
+
+This runbook outlines the tasks required to ship the first production-ready version of the Twilio-powered marketing command center today. It assumes the current frontend (React + Tailwind + shadcn-ui), Supabase backend scaffolding, and Twilio alerting functions that already exist in the repository.
+
+## 0. Pre-flight checklist (blockers)
+- [ ] Confirm Supabase project is provisioned and migrations in `supabase/migrations` are applied via `supabase db push`.
+- [ ] Ensure Twilio account has verified senders and required numbers (SMS + optional WhatsApp).
+- [ ] Collect environment secrets for Supabase (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`) and Twilio (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`).
+- [ ] Configure CI/CD credentials for both Supabase and the hosting platform (Lovable / Vercel / custom).
+- [ ] Decide on a single source of truth for configuration (e.g., Supabase Vault + Supabase secrets).
+
+## 1. Backend enablement (Supabase + Twilio functions)
+1. Apply migrations and confirm tables (`projects`, `builds`, `project_latest_build`) and triggers are present as described in `supabase/README.md`.
+2. Deploy `report-build` edge function and set `BUILD_REPORT_TOKEN`. Validate with curl against the local Supabase functions serve URL.
+3. Deploy `twilio-build-alert` edge function and set Twilio credentials (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`, `TWILIO_TO_NUMBERS`) along with `TWILIO_ALERT_TOKEN`.
+4. Update Postgres parameter `app.twilio_alert_token` with the same token to keep the trigger in sync.
+5. Create REST policies for new tables so the frontend can read/write campaign data once endpoints are introduced.
+6. Draft Supabase SQL or RPC endpoints for campaign management (create campaign, schedule sends, list analytics) that align with the mock data currently in the UI.
+7. Stand up a Supabase cron or background job (e.g., edge function invoked by scheduler) that pushes campaign events to Twilio Studio / Messaging API.
+8. Document fallback and retry strategy (e.g., requeue failed sends, store Twilio message SID + status updates).
+
+## 2. Frontend wiring (React dashboard)
+1. Replace mock Twilio config state in `src/components/TwilioConfig.tsx` with React Query calls to secure Supabase endpoints for fetching/storing credentials. Use Supabase functions to avoid exposing service role keys to the client.
+2. Surface connection status by calling a lightweight health-check endpoint that validates Twilio credentials server-side.
+3. Implement journey builder persistence: map each step to a Supabase table and hydrate UI state on load.
+4. Connect campaign creation forms to Supabase RPC endpoints; ensure validation with `react-hook-form` + `zod` matches backend constraints.
+5. Add optimistic UI and loading/error states for Twilio sends so operators see status in real time.
+6. Instrument usage analytics (e.g., Supabase logs or PostHog) to monitor adoption post-launch.
+
+## 3. Automation, QA, and observability
+1. Establish end-to-end test coverage for Twilio workflows using mocked Twilio API responses.
+2. Add lint/type/test commands to CI (`npm run lint`, `npm run typecheck`, `npm run test` once configured).
+3. Use Supabase Edge Function tests or integration suite to validate Twilio webhooks before enabling real traffic.
+4. Configure alerting when `twilio-build-alert` fires frequently (to catch systemic issues).
+5. Implement feature flags for risky features so you can toggle them off quickly.
+
+## 4. Launch logistics (today)
+1. Freeze the main branch after merging critical fixes; tag a release candidate.
+2. Run smoke tests against staging environment (Supabase project + Twilio sandbox) covering:
+   - Credential save/test flows in Twilio settings UI.
+   - Campaign creation and send dry run.
+   - Workflow deployment checklist in `WorkflowManager` page.
+3. Promote Supabase and frontend configs to production secrets.
+4. Point DNS / hosting to the production build and verify SSL.
+5. Announce launch internally with runbook links and on-call contact info.
+6. Schedule first post-launch review (24 hours later) to evaluate metrics and triage issues.
+
+## 5. Post-launch guardrails
+- Monitor Supabase logs for errors and Twilio for delivery failures.
+- Prepare rollback plan: redeploy previous build, revoke Twilio secrets, or switch traffic to maintenance page.
+- Iterate on onboarding docs so new team members can repeat this launch without missing steps.
+
+## Appendix: useful commands
+```bash
+# Apply Supabase migrations
+supabase db push
+
+# Deploy edge functions
+supabase functions deploy report-build
+supabase functions deploy twilio-build-alert
+
+# Serve functions locally for integration testing
+supabase functions serve --env-file ./supabase/.env.local
+```

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -14,6 +14,7 @@ import {
   AlertTriangle,
   Bell,
   CheckCircle2,
+  Info,
   LineChart,
   Plus,
   Settings,
@@ -341,6 +342,7 @@ const Dashboard = () => {
   const [projects, setProjects] = useState<UiProject[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [usingDemoData, setUsingDemoData] = useState(false);
   const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const loadProjects = useCallback(
@@ -368,6 +370,7 @@ const Dashboard = () => {
         setError(supabaseError.message);
         setProjects([]);
         setLoading(false);
+        setUsingDemoData(false);
         return;
       }
 
@@ -379,6 +382,7 @@ const Dashboard = () => {
       });
 
       setProjects(normalized);
+      setUsingDemoData(false);
       setError(null);
       setLoading(false);
     },
@@ -387,11 +391,16 @@ const Dashboard = () => {
 
   useEffect(() => {
     if (!supabase) {
-      setProjects(demoProjects);
-      setError(
-        "Supabase credentials are not configured. Displaying live demo data instead.",
+      setProjects(
+        demoProjects.map((project) => ({
+          ...project,
+          builds: project.builds.map((build) => ({ ...build })),
+          latestBuild: project.builds[0],
+        })),
       );
       setLoading(false);
+      setError(null);
+      setUsingDemoData(true);
       return;
     }
 
@@ -402,6 +411,7 @@ const Dashboard = () => {
         setError(String(err));
         setProjects([]);
         setLoading(false);
+        setUsingDemoData(false);
       }
     });
 
@@ -501,6 +511,25 @@ const Dashboard = () => {
                 <p className="font-semibold">Realtime telemetry degraded</p>
                 <p className="text-corporate-silver">
                   {error}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {usingDemoData && (
+        <Card className="executive-card border-corporate-blue/60 mb-8 bg-corporate-blue/5">
+          <CardContent className="p-6">
+            <div className="flex items-start gap-3 text-sm text-corporate-platinum">
+              <Info className="h-5 w-5 text-corporate-blue mt-0.5" />
+              <div>
+                <p className="font-semibold">Running in showcase mode</p>
+                <p className="text-corporate-silver">
+                  Populate <code className="text-xs px-1 py-0.5 bg-corporate-charcoal rounded">VITE_SUPABASE_URL</code> and
+                  <code className="ml-1 text-xs px-1 py-0.5 bg-corporate-charcoal rounded">VITE_SUPABASE_ANON_KEY</code> in your
+                  environment to stream live build telemetry from Supabase. Until then, curated demo data keeps the dashboard
+                  fully interactive.
                 </p>
               </div>
             </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,19 +4,23 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const base = mode === "production" ? process.env.VITE_BASE_PATH ?? "./" : "/";
+
+  return {
+    base,
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins: [
+      react(),
+      mode === "development" && componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- document the end-to-end launch steps for the Twilio marketing platform in a dedicated runbook
- outline backend, frontend, QA, and go-live tasks aligned with the existing Supabase and Twilio scaffolding
- add a GitHub Pages deployment workflow so stakeholders can load the UI from a published GitHub URL
- harden the dashboard to fall back to curated demo data with clear Supabase configuration guidance
- configure Vite builds for relocatable hosting and document local environment plus deployment guardrails

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c898844d8483288280e4b7e30bbeef

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GitHub Pages deployment workflow, README overhaul, dashboard demo mode with guidance, Vite base-path config, and a Twilio launch runbook.
> 
> - **CI/CD**
>   - **GitHub Pages Deploy**: New workflow in `.github/workflows/deploy.yml` builds (Node 20, npm ci) with `VITE_BASE_PATH=./`, uploads `dist`, and deploys via `actions/deploy-pages@v4` on `main` and manual runs.
> - **Frontend**
>   - **Dashboard demo fallback**: `src/components/Dashboard.tsx` adds `usingDemoData` state and a showcase-mode banner; auto-populates curated demo data when Supabase is not configured; resets flags on errors/success.
> - **Build/Config**
>   - **Vite base path**: `vite.config.ts` sets `base` to `"./"` in production (overridable via `VITE_BASE_PATH`), preserving dev `/`.
> - **Docs**
>   - **README rewrite**: Project-specific setup, env vars (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`), Pages deployment steps, and quality checklist.
>   - **Runbook**: New `docs/twilio-launch-runbook.md` outlining backend, frontend, QA, launch, and post-launch tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 459fd2ae23a2ac6f35a88311f08f5c2445066cb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->