### PR TITLE
feat: add studio canvas builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
+        "reactflow": "^11.11.4",
         "recharts": "^2.12.7",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
@@ -2310,6 +2311,108 @@
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
       "license": "MIT"
     },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
@@ -2897,10 +3000,72 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
       "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -2909,10 +3074,83 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -2930,6 +3168,24 @@
       "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
@@ -2938,6 +3194,18 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.6",
@@ -2954,17 +3222,48 @@
       "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3595,6 +3894,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4068,6 +4373,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -4123,6 +4450,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -4164,6 +4500,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -6291,6 +6662,24 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6950,6 +7339,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7233,6 +7631,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
+    "reactflow": "^11.11.4",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",

--- a/src/components/TwilioWorkflowManager.tsx
+++ b/src/components/TwilioWorkflowManager.tsx
@@ -1,15 +1,350 @@
+import React, { DragEvent, useCallback, useMemo, useRef, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Connection,
+  Controls,
+  Edge,
+  MarkerType,
+  MiniMap,
+  Node,
+  NodeProps,
+  ReactFlowInstance,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+  addEdge,
+  Handle,
+  Position
+} from 'reactflow';
+import 'reactflow/dist/style.css';
 
-import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { Settings, Plus, List } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { List, Plus, Workflow } from 'lucide-react';
+
+interface WorkflowSummary {
+  id: string;
+  name: string;
+  sid: string;
+  status: 'Active' | 'Standby' | 'Inactive';
+  type: string;
+  tasks: number;
+  avgWaitTime: string;
+  efficiency: string;
+}
+
+interface NewWorkflowState {
+  name: string;
+  type: string;
+  queue: string;
+  priority: string;
+}
+
+interface StudioNodeData {
+  label: string;
+  channel: string;
+  description: string;
+  fallback?: boolean;
+}
+
+interface StudioPaletteItem {
+  type: StudioBlueprintNodeType;
+  label: string;
+  channel: string;
+  description: string;
+  accent: string;
+}
+
+type StudioBlueprintNodeType =
+  | 'trigger'
+  | 'profile'
+  | 'rcs'
+  | 'status-check'
+  | 'sms'
+  | 'wait'
+  | 'reminder'
+  | 'escalate'
+  | 'analytics';
+
+const studioPalette: StudioPaletteItem[] = [
+  {
+    type: 'trigger',
+    label: 'Campaign Trigger',
+    channel: 'HTTP Trigger',
+    description: 'Kick off flow from Supabase Edge Functions, Segment, or Zapier.',
+    accent: 'from-sky-500 to-sky-400'
+  },
+  {
+    type: 'profile',
+    label: 'Profile Lookup',
+    channel: 'Supabase RPC',
+    description: 'Hydrate customer preferences, opt-in and sentiment.',
+    accent: 'from-violet-500 to-violet-400'
+  },
+  {
+    type: 'rcs',
+    label: 'Send RCS',
+    channel: 'RCS Rich Card',
+    description: 'Deliver hero offers with carousel buttons and callbacks.',
+    accent: 'from-emerald-500 to-emerald-400'
+  },
+  {
+    type: 'status-check',
+    label: 'Delivery Split',
+    channel: 'Callback Event',
+    description: 'Branch when delivery fails or timeout occurs.',
+    accent: 'from-amber-500 to-amber-400'
+  },
+  {
+    type: 'sms',
+    label: 'Send SMS Fallback',
+    channel: 'SMS',
+    description: 'Graceful fallback copy with shortened tracking links.',
+    accent: 'from-rose-500 to-rose-400'
+  },
+  {
+    type: 'wait',
+    label: 'Wait For Reply',
+    channel: 'Split Based On',
+    description: 'Listen for responses, escalate positive conversions.',
+    accent: 'from-indigo-500 to-indigo-400'
+  },
+  {
+    type: 'reminder',
+    label: 'Reminder Nudge',
+    channel: 'SMS + Email',
+    description: 'Follow-up blend to keep journey alive and compliant.',
+    accent: 'from-cyan-500 to-cyan-400'
+  },
+  {
+    type: 'escalate',
+    label: 'Flex Escalation',
+    channel: 'TaskRouter',
+    description: 'Create prioritized Flex task with transcripts.',
+    accent: 'from-fuchsia-500 to-fuchsia-400'
+  },
+  {
+    type: 'analytics',
+    label: 'Analytics Update',
+    channel: 'Supabase',
+    description: 'Persist conversions, opt-outs, and attribution.',
+    accent: 'from-lime-500 to-lime-400'
+  }
+];
+
+const initialStudioNodes: Node<StudioNodeData>[] = [
+  {
+    id: 'trigger',
+    position: { x: 0, y: 0 },
+    type: 'studioNode',
+    data: {
+      label: 'Campaign Trigger',
+      channel: 'HTTP Trigger',
+      description: 'Start from Supabase Edge Function or inbound webhook.'
+    }
+  },
+  {
+    id: 'profile-lookup',
+    position: { x: 260, y: -40 },
+    type: 'studioNode',
+    data: {
+      label: 'Profile Lookup',
+      channel: 'Supabase RPC',
+      description: 'Enrich contact metadata + channel preferences.'
+    }
+  },
+  {
+    id: 'send-rcs',
+    position: { x: 520, y: -80 },
+    type: 'studioNode',
+    data: {
+      label: 'Send RCS Rich Card',
+      channel: 'RCS',
+      description: 'Send carousel with CTAs and record delivery callbacks.'
+    }
+  },
+  {
+    id: 'delivery-check',
+    position: { x: 520, y: 120 },
+    type: 'studioNode',
+    data: {
+      label: 'Delivery Status Split',
+      channel: 'Callback Event',
+      description: 'Branch when delivery fails or times out.',
+      fallback: true
+    }
+  },
+  {
+    id: 'send-sms',
+    position: { x: 780, y: 80 },
+    type: 'studioNode',
+    data: {
+      label: 'Send SMS Fallback',
+      channel: 'SMS',
+      description: 'Fallback copy with short link and opt-out language.',
+      fallback: true
+    }
+  },
+  {
+    id: 'wait',
+    position: { x: 780, y: -120 },
+    type: 'studioNode',
+    data: {
+      label: 'Wait For Reply',
+      channel: 'Split Based On',
+      description: 'Route positive sentiment to Flex agents.'
+    }
+  },
+  {
+    id: 'reminder',
+    position: { x: 1040, y: 120 },
+    type: 'studioNode',
+    data: {
+      label: 'Reminder Nudge',
+      channel: 'SMS + Email',
+      description: 'Re-engage after 1 hour with multi-channel message.',
+      fallback: true
+    }
+  },
+  {
+    id: 'flex',
+    position: { x: 1040, y: -80 },
+    type: 'studioNode',
+    data: {
+      label: 'Flex Escalation',
+      channel: 'TaskRouter',
+      description: 'Create Flex task with transcript + campaign context.'
+    }
+  },
+  {
+    id: 'analytics',
+    position: { x: 1320, y: -40 },
+    type: 'studioNode',
+    data: {
+      label: 'Analytics Update',
+      channel: 'Supabase',
+      description: 'Persist engagement + attribution insights.'
+    }
+  }
+];
+
+const initialStudioEdges: Edge[] = [
+  {
+    id: 'e-trigger-profile',
+    source: 'trigger',
+    target: 'profile-lookup',
+    type: 'smoothstep',
+    animated: true,
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#38bdf8', strokeWidth: 2 }
+  },
+  {
+    id: 'e-profile-rcs',
+    source: 'profile-lookup',
+    target: 'send-rcs',
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#22c55e', strokeWidth: 2 }
+  },
+  {
+    id: 'e-profile-delivery',
+    source: 'profile-lookup',
+    target: 'delivery-check',
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#f97316', strokeWidth: 2 }
+  },
+  {
+    id: 'e-rcs-wait',
+    source: 'send-rcs',
+    target: 'wait',
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#0ea5e9', strokeWidth: 2 }
+  },
+  {
+    id: 'e-delivery-sms',
+    source: 'delivery-check',
+    target: 'send-sms',
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#f97316', strokeWidth: 2 }
+  },
+  {
+    id: 'e-sms-reminder',
+    source: 'send-sms',
+    target: 'reminder',
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#f97316', strokeWidth: 2 }
+  },
+  {
+    id: 'e-wait-flex',
+    source: 'wait',
+    target: 'flex',
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#22c55e', strokeWidth: 2 }
+  },
+  {
+    id: 'e-flex-analytics',
+    source: 'flex',
+    target: 'analytics',
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#6366f1', strokeWidth: 2 }
+  },
+  {
+    id: 'e-reminder-flex',
+    source: 'reminder',
+    target: 'flex',
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: { stroke: '#f97316', strokeWidth: 2 }
+  }
+];
+
+const StudioNode = ({ data }: NodeProps<StudioNodeData>) => {
+  const baseGradient = data.fallback ? 'from-amber-500 to-rose-500' : 'from-sky-500 to-emerald-500';
+
+  return (
+    <div className="w-[240px] rounded-2xl border border-white/20 bg-slate-900/70 backdrop-blur shadow-lg shadow-black/20">
+      <div className={`rounded-t-2xl px-4 py-2 text-xs font-semibold uppercase text-slate-900 bg-gradient-to-r ${baseGradient}`}>
+        {data.channel}
+      </div>
+      <div className="space-y-1 px-4 py-3">
+        <p className="text-base font-semibold text-slate-100">{data.label}</p>
+        <p className="text-xs text-slate-300">{data.description}</p>
+      </div>
+      <Handle type="target" position={Position.Left} className="h-3 w-3 bg-slate-100" />
+      <Handle type="source" position={Position.Right} className="h-3 w-3 bg-primary" />
+    </div>
+  );
+};
+
+const nodeTypes = { studioNode: StudioNode };
+
+const getStatusColor = (status: WorkflowSummary['status']) => {
+  switch (status) {
+    case 'Active':
+      return 'bg-tactical-green text-black';
+    case 'Standby':
+      return 'bg-tactical-yellow text-black';
+    case 'Inactive':
+      return 'bg-tactical-red text-white';
+    default:
+      return 'bg-secondary';
+  }
+};
 
 const TwilioWorkflowManager = () => {
-  const [workflows, setWorkflows] = useState([
+  const [workflows] = useState<WorkflowSummary[]>([
     {
       id: 'wf-1',
       name: 'Customer Support Queue',
@@ -42,176 +377,441 @@ const TwilioWorkflowManager = () => {
     }
   ]);
 
-  const [newWorkflow, setNewWorkflow] = useState({
+  const [newWorkflow, setNewWorkflow] = useState<NewWorkflowState>({
     name: '',
     type: '',
     queue: '',
     priority: ''
   });
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'Active': return 'bg-tactical-green text-black';
-      case 'Standby': return 'bg-tactical-yellow text-black';
-      case 'Inactive': return 'bg-tactical-red text-white';
-      default: return 'bg-secondary';
-    }
+  const studioFlowBlueprint = {
+    name: 'RCS-First Lead Nurture Journey',
+    objective:
+      'Deliver a rich marketing experience via RCS with automated SMS fallback and human escalation for high-intent leads.',
+    channels: ['RCS / Google Business Messages', 'SMS Fallback', 'Email Backup', 'Flex Agent Escalation'],
+    entryPoints: ['Supabase Edge Function webhook', 'Zapier or Segment marketing trigger', 'Manual agent injection'],
+    sla: 'Respond within 5 minutes or automatically re-engage'
   };
 
+  const studioFlowSteps = [
+    {
+      step: '1',
+      action: 'Inbound Campaign Webhook',
+      channel: 'HTTP Trigger',
+      outcome: 'Start Studio Flow with contact metadata from Supabase profile enrichment.'
+    },
+    {
+      step: '2',
+      action: 'Profile Lookup',
+      channel: 'Function / Supabase RPC',
+      outcome: 'Fetch opt-in status, preferred channel, and previous conversion notes.'
+    },
+    {
+      step: '3',
+      action: 'Send RCS Rich Card',
+      channel: 'RCS',
+      outcome: 'Deliver carousel with offer hero image, CTA buttons, and track delivery callbacks.'
+    },
+    {
+      step: '4',
+      action: 'Delivery Status Split',
+      channel: 'Callback Event',
+      outcome: 'If RCS not delivered within 90 seconds, branch to SMS fallback path.'
+    },
+    {
+      step: '5',
+      action: 'Fallback SMS Campaign',
+      channel: 'SMS',
+      outcome: 'Send concise copy with shortened tracking link and opt-out language.'
+    },
+    {
+      step: '6',
+      action: 'Wait for Customer Reply',
+      channel: 'Studio Split Based On Input',
+      outcome: 'Positive intent routes to Flex task; negative or no response triggers reminder.'
+    },
+    {
+      step: '7',
+      action: 'Reminder Nudge',
+      channel: 'SMS + Email',
+      outcome: 'After 1 hour send MMS reminder and optional email to keep journey alive.'
+    },
+    {
+      step: '8',
+      action: 'Flex Agent Escalation',
+      channel: 'TaskRouter',
+      outcome: 'Create prioritized task with transcript and campaign context.'
+    },
+    {
+      step: '9',
+      action: 'Supabase Analytics Update',
+      channel: 'PostgREST',
+      outcome: 'Write engagement outcome, conversions, and time-to-response for dashboards.'
+    }
+  ];
+
+  const [nodes, setNodes, onNodesChange] = useNodesState<StudioNodeData>(initialStudioNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialStudioEdges);
+  const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
+  const reactFlowWrapper = useRef<HTMLDivElement | null>(null);
+
+  const onConnect = useCallback(
+    (connection: Edge | Connection) =>
+      setEdges((eds) =>
+        addEdge(
+          {
+            ...connection,
+            type: 'smoothstep',
+            markerEnd: { type: MarkerType.ArrowClosed },
+            style: { stroke: '#38bdf8', strokeWidth: 2 }
+          },
+          eds
+        )
+      ),
+    [setEdges]
+  );
+
+  const paletteLookup = useMemo(() => {
+    return studioPalette.reduce<Record<StudioBlueprintNodeType, StudioPaletteItem>>((acc, item) => {
+      acc[item.type] = item;
+      return acc;
+    }, {} as Record<StudioBlueprintNodeType, StudioPaletteItem>);
+  }, []);
+
+  const onDragStart = useCallback((event: DragEvent<HTMLDivElement>, nodeType: StudioBlueprintNodeType) => {
+    event.dataTransfer.setData('application/reactflow', nodeType);
+    event.dataTransfer.effectAllowed = 'move';
+  }, []);
+
+  const onDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const onDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const type = event.dataTransfer.getData('application/reactflow') as StudioBlueprintNodeType | '';
+
+      if (!type || !reactFlowWrapper.current || !reactFlowInstance) return;
+
+      const bounds = reactFlowWrapper.current.getBoundingClientRect();
+      const position = reactFlowInstance.project({
+        x: event.clientX - bounds.left,
+        y: event.clientY - bounds.top
+      });
+
+      const paletteNode = paletteLookup[type];
+      if (!paletteNode) return;
+
+      const id = `${type}-${Date.now()}`;
+      const newNode: Node<StudioNodeData> = {
+        id,
+        position,
+        type: 'studioNode',
+        data: {
+          label: paletteNode.label,
+          channel: paletteNode.channel,
+          description: paletteNode.description,
+          fallback: ['sms', 'reminder'].includes(type)
+        }
+      };
+
+      setNodes((nds) => nds.concat(newNode));
+    },
+    [paletteLookup, reactFlowInstance, setNodes]
+  );
+
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3 mb-6">
-        <List className="h-6 w-6 text-primary" />
-        <h2 className="text-2xl font-bold text-primary">Workflow Command Center</h2>
-      </div>
+    <ReactFlowProvider>
+      <div className="space-y-6">
+        <div className="flex items-center gap-3 mb-6">
+          <List className="h-6 w-6 text-primary" />
+          <h2 className="text-2xl font-bold text-primary">Workflow Command Center</h2>
+        </div>
 
-      {/* Create New Workflow */}
-      <Card className="border-border bg-card/50 backdrop-blur">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Plus className="h-5 w-5" />
-            Deploy New Workflow
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            <div>
-              <Label htmlFor="workflowName">Workflow Name</Label>
-              <Input
-                id="workflowName"
-                placeholder="Support Queue"
-                value={newWorkflow.name}
-                onChange={(e) => setNewWorkflow(prev => ({ ...prev, name: e.target.value }))}
-                className="mt-1"
-              />
-            </div>
-            <div>
-              <Label>Workflow Type</Label>
-              <Select onValueChange={(value) => setNewWorkflow(prev => ({ ...prev, type: value }))}>
-                <SelectTrigger className="mt-1">
-                  <SelectValue placeholder="Select type" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="taskrouter">TaskRouter</SelectItem>
-                  <SelectItem value="studio">Studio Flow</SelectItem>
-                  <SelectItem value="functions">Twilio Functions</SelectItem>
-                  <SelectItem value="flex">Flex Plugin</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label>Target Queue</Label>
-              <Select onValueChange={(value) => setNewWorkflow(prev => ({ ...prev, queue: value }))}>
-                <SelectTrigger className="mt-1">
-                  <SelectValue placeholder="Select queue" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="support">Customer Support</SelectItem>
-                  <SelectItem value="sales">Sales Team</SelectItem>
-                  <SelectItem value="technical">Technical Support</SelectItem>
-                  <SelectItem value="billing">Billing Inquiries</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label>Priority Level</Label>
-              <Select onValueChange={(value) => setNewWorkflow(prev => ({ ...prev, priority: value }))}>
-                <SelectTrigger className="mt-1">
-                  <SelectValue placeholder="Set priority" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="high">High Priority</SelectItem>
-                  <SelectItem value="normal">Normal</SelectItem>
-                  <SelectItem value="low">Low Priority</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-          <Button className="mt-4 glow-blue">
-            Deploy Workflow
-          </Button>
-        </CardContent>
-      </Card>
+        <Tabs defaultValue="overview" className="space-y-6">
+          <TabsList className="w-full md:w-auto">
+            <TabsTrigger value="overview">Operations Dashboard</TabsTrigger>
+            <TabsTrigger value="studio">Studio Flow Canvas</TabsTrigger>
+          </TabsList>
 
-      {/* Workflow Monitoring */}
-      <Card className="border-border bg-card/50 backdrop-blur">
-        <CardHeader>
-          <CardTitle>Real-time Workflow Metrics</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <div className="text-center">
-              <p className="text-sm text-muted-foreground">Active Workflows</p>
-              <p className="text-3xl font-bold text-tactical-green">
-                {workflows.filter(w => w.status === 'Active').length}
-              </p>
-            </div>
-            <div className="text-center">
-              <p className="text-sm text-muted-foreground">Total Tasks</p>
-              <p className="text-3xl font-bold text-tactical-cyan">
-                {workflows.reduce((sum, w) => sum + w.tasks, 0)}
-              </p>
-            </div>
-            <div className="text-center">
-              <p className="text-sm text-muted-foreground">Avg Wait Time</p>
-              <p className="text-3xl font-bold text-primary">1:54</p>
-            </div>
-            <div className="text-center">
-              <p className="text-sm text-muted-foreground">System Efficiency</p>
-              <p className="text-3xl font-bold text-tactical-green">96%</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Workflow List */}
-      <div className="grid gap-4">
-        {workflows.map((workflow) => (
-          <Card key={workflow.id} className="border-border bg-card/50 backdrop-blur">
-            <CardContent className="p-6">
-              <div className="flex items-start justify-between mb-4">
-                <div>
-                  <div className="flex items-center gap-3 mb-2">
-                    <h3 className="text-xl font-semibold">{workflow.name}</h3>
-                    <Badge className={getStatusColor(workflow.status)}>
-                      {workflow.status}
-                    </Badge>
-                    <Badge variant="outline">{workflow.type}</Badge>
+          <TabsContent value="overview" className="space-y-6">
+            <Card className="border-border bg-card/50 backdrop-blur">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Plus className="h-5 w-5" />
+                  Deploy New Workflow
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                  <div>
+                    <Label htmlFor="workflowName">Workflow Name</Label>
+                    <Input
+                      id="workflowName"
+                      placeholder="Support Queue"
+                      value={newWorkflow.name}
+                      onChange={(e) => setNewWorkflow((prev) => ({ ...prev, name: e.target.value }))}
+                      className="mt-1"
+                    />
                   </div>
-                  <p className="text-sm text-muted-foreground">SID: {workflow.sid}</p>
+                  <div>
+                    <Label>Workflow Type</Label>
+                    <Select onValueChange={(value) => setNewWorkflow((prev) => ({ ...prev, type: value }))}>
+                      <SelectTrigger className="mt-1">
+                        <SelectValue placeholder="Select type" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="taskrouter">TaskRouter</SelectItem>
+                        <SelectItem value="studio">Studio Flow</SelectItem>
+                        <SelectItem value="functions">Twilio Functions</SelectItem>
+                        <SelectItem value="flex">Flex Plugin</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label>Target Queue</Label>
+                    <Select onValueChange={(value) => setNewWorkflow((prev) => ({ ...prev, queue: value }))}>
+                      <SelectTrigger className="mt-1">
+                        <SelectValue placeholder="Select queue" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="support">Customer Support</SelectItem>
+                        <SelectItem value="sales">Sales Team</SelectItem>
+                        <SelectItem value="technical">Technical Support</SelectItem>
+                        <SelectItem value="billing">Billing Inquiries</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label>Priority Level</Label>
+                    <Select onValueChange={(value) => setNewWorkflow((prev) => ({ ...prev, priority: value }))}>
+                      <SelectTrigger className="mt-1">
+                        <SelectValue placeholder="Set priority" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="high">High Priority</SelectItem>
+                        <SelectItem value="normal">Normal</SelectItem>
+                        <SelectItem value="low">Low Priority</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
-                <div className="flex gap-2">
-                  <Button variant="outline" size="sm">Configure</Button>
-                  <Button variant="outline" size="sm">Monitor</Button>
-                  <Button variant="outline" size="sm">
-                    {workflow.status === 'Active' ? 'Pause' : 'Activate'}
-                  </Button>
-                </div>
-              </div>
+                <Button className="mt-4 glow-blue">Deploy Workflow</Button>
+              </CardContent>
+            </Card>
 
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="text-center">
-                  <p className="text-sm text-muted-foreground">Active Tasks</p>
-                  <p className="text-2xl font-bold text-primary">{workflow.tasks}</p>
+            <Card className="border-border bg-card/50 backdrop-blur">
+              <CardHeader>
+                <CardTitle>Real-time Workflow Metrics</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+                  <div className="text-center">
+                    <p className="text-sm text-muted-foreground">Active Workflows</p>
+                    <p className="text-3xl font-bold text-tactical-green">
+                      {workflows.filter((w) => w.status === 'Active').length}
+                    </p>
+                  </div>
+                  <div className="text-center">
+                    <p className="text-sm text-muted-foreground">Total Tasks</p>
+                    <p className="text-3xl font-bold text-tactical-cyan">
+                      {workflows.reduce((sum, w) => sum + w.tasks, 0)}
+                    </p>
+                  </div>
+                  <div className="text-center">
+                    <p className="text-sm text-muted-foreground">Avg Wait Time</p>
+                    <p className="text-3xl font-bold text-primary">1:54</p>
+                  </div>
+                  <div className="text-center">
+                    <p className="text-sm text-muted-foreground">System Efficiency</p>
+                    <p className="text-3xl font-bold text-tactical-green">96%</p>
+                  </div>
                 </div>
-                <div className="text-center">
-                  <p className="text-sm text-muted-foreground">Avg Wait Time</p>
-                  <p className="text-2xl font-bold text-tactical-cyan">{workflow.avgWaitTime}</p>
+              </CardContent>
+            </Card>
+
+            <div className="grid gap-4">
+              {workflows.map((workflow) => (
+                <Card key={workflow.id} className="border-border bg-card/50 backdrop-blur">
+                  <CardContent className="p-6">
+                    <div className="flex items-start justify-between mb-4">
+                      <div>
+                        <div className="flex items-center gap-3 mb-2">
+                          <h3 className="text-xl font-semibold">{workflow.name}</h3>
+                          <Badge className={getStatusColor(workflow.status)}>{workflow.status}</Badge>
+                          <Badge variant="outline">{workflow.type}</Badge>
+                        </div>
+                        <p className="text-sm text-muted-foreground">SID: {workflow.sid}</p>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button variant="outline" size="sm">
+                          Configure
+                        </Button>
+                        <Button variant="outline" size="sm">
+                          Monitor
+                        </Button>
+                        <Button variant="outline" size="sm">
+                          {workflow.status === 'Active' ? 'Pause' : 'Activate'}
+                        </Button>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                      <div className="text-center">
+                        <p className="text-sm text-muted-foreground">Active Tasks</p>
+                        <p className="text-2xl font-bold text-primary">{workflow.tasks}</p>
+                      </div>
+                      <div className="text-center">
+                        <p className="text-sm text-muted-foreground">Avg Wait Time</p>
+                        <p className="text-2xl font-bold text-tactical-cyan">{workflow.avgWaitTime}</p>
+                      </div>
+                      <div className="text-center">
+                        <p className="text-sm text-muted-foreground">Efficiency</p>
+                        <p className="text-2xl font-bold text-tactical-green">{workflow.efficiency}</p>
+                      </div>
+                      <div className="text-center">
+                        <p className="text-sm text-muted-foreground">Type</p>
+                        <p className="text-2xl font-bold text-tactical-cyan">{workflow.type}</p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="studio" className="space-y-6">
+            <Card className="border-border bg-card/60 backdrop-blur">
+              <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <CardTitle className="flex items-center gap-2">
+                    <Workflow className="h-5 w-5" />
+                    Studio Blueprint Canvas
+                  </CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Drag widgets onto the canvas to design a Twilio Studio experience with RCS-first routing.
+                  </p>
                 </div>
-                <div className="text-center">
-                  <p className="text-sm text-muted-foreground">Efficiency</p>
-                  <p className="text-2xl font-bold text-tactical-green">{workflow.efficiency}</p>
+                <div className="text-xs text-muted-foreground">
+                  Tip: Connect nodes by dragging between handles. Use fallback nodes to model resilience.
                 </div>
-                <div className="text-center">
-                  <p className="text-sm text-muted-foreground">Type</p>
-                  <p className="text-lg font-bold text-foreground">{workflow.type}</p>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+                  <div className="space-y-4">
+                    <div className="rounded-2xl border border-border/60 bg-slate-900/60 p-4 shadow-inner">
+                      <h3 className="text-sm font-semibold text-primary">Blueprint Settings</h3>
+                      <div className="mt-3 space-y-2 text-xs text-muted-foreground">
+                        <p>
+                          <span className="font-semibold text-foreground">Objective:</span> {studioFlowBlueprint.objective}
+                        </p>
+                        <p>
+                          <span className="font-semibold text-foreground">Channels:</span> {studioFlowBlueprint.channels.join(', ')}
+                        </p>
+                        <p>
+                          <span className="font-semibold text-foreground">Entry Points:</span> {studioFlowBlueprint.entryPoints.join(', ')}
+                        </p>
+                        <p>
+                          <span className="font-semibold text-foreground">SLA:</span> {studioFlowBlueprint.sla}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="space-y-3">
+                      <h3 className="text-sm font-semibold text-primary">Drag &amp; Drop Widgets</h3>
+                      {studioPalette.map((item) => (
+                        <div
+                          key={item.type}
+                          draggable
+                          onDragStart={(event) => onDragStart(event, item.type)}
+                          className={`cursor-grab rounded-2xl border border-white/10 bg-gradient-to-r ${item.accent} p-4 text-white shadow-lg transition hover:scale-[1.01] active:cursor-grabbing`}
+                        >
+                          <p className="text-sm font-semibold">{item.label}</p>
+                          <p className="text-xs text-white/80">{item.channel}</p>
+                          <p className="mt-1 text-[11px] text-white/70">{item.description}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-4">
+                    <div ref={reactFlowWrapper} className="h-[540px] overflow-hidden rounded-3xl border border-border/60 bg-slate-950/80">
+                      <ReactFlow
+                        nodes={nodes}
+                        edges={edges}
+                        onNodesChange={onNodesChange}
+                        onEdgesChange={onEdgesChange}
+                        onConnect={onConnect}
+                        nodeTypes={nodeTypes}
+                        fitView
+                        fitViewOptions={{ padding: 0.2 }}
+                        onInit={setReactFlowInstance}
+                        onDrop={onDrop}
+                        onDragOver={onDragOver}
+                        panOnScroll
+                        panOnDrag={[1, 2]}
+                        zoomOnPinch
+                        minZoom={0.4}
+                        maxZoom={1.5}
+                      >
+                        <Background color="#1e293b" gap={24} />
+                        <MiniMap pannable zoomable />
+                        <Controls position="bottom-left" />
+                      </ReactFlow>
+                    </div>
+                    <div className="rounded-2xl border border-border/60 bg-slate-900/60 p-4">
+                      <h3 className="text-sm font-semibold text-primary">Studio JSON Starter</h3>
+                      <pre className="mt-2 max-h-52 overflow-auto rounded-xl bg-slate-950/80 p-4 text-xs text-slate-200">
+{`{
+  "states": [
+    { "name": "trigger", "type": "trigger" },
+    { "name": "profile_lookup", "type": "run-function", "properties": { "service_sid": "ZSxxxxxxxx" } },
+    { "name": "send_rcs", "type": "send-and-wait-for-reply", "properties": { "channel": "rcs" } },
+    { "name": "delivery_split", "type": "split-based-on", "properties": { "input": "{{widgets.send_rcs.delivery_status}}" } },
+    { "name": "send_sms", "type": "send-message", "properties": { "channel": "sms" } },
+    { "name": "flex_task", "type": "create-task", "properties": { "workspace": "Flex" } }
+  ]
+}`}
+                      </pre>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
+              </CardContent>
+            </Card>
+
+            <Card className="border-border bg-card/60 backdrop-blur">
+              <CardHeader>
+                <CardTitle>RCS-First Journey Breakdown</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[60px]">Step</TableHead>
+                      <TableHead>Action</TableHead>
+                      <TableHead>Channel</TableHead>
+                      <TableHead>Outcome</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {studioFlowSteps.map((step) => (
+                      <TableRow key={step.step}>
+                        <TableCell className="font-semibold">{step.step}</TableCell>
+                        <TableCell>{step.action}</TableCell>
+                        <TableCell>{step.channel}</TableCell>
+                        <TableCell className="text-sm text-muted-foreground">{step.outcome}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
       </div>
-    </div>
+    </ReactFlowProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace the static Studio tab with a drag-and-drop React Flow canvas that mirrors a Twilio Studio journey, including reusable widget palette and live connection editing
- render curated blueprint metadata, starter JSON, and the existing operations dashboard so campaign planners can move between deployment metrics and visual design seamlessly
- add the React Flow dependency to support node-based authoring and interaction controls

## Testing
- npm run lint *(fails: repository still contains upstream merge-conflict markers in src/components/ui/command.tsx and src/components/ui/textarea.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7415b7a0832888868ee5fcd2eff6