### PR TITLE
Restyle dashboard with liquid glass default skin

### DIFF
--- a/docs/skin-showcase.md
+++ b/docs/skin-showcase.md
@@ -1,0 +1,15 @@
+# Dashboard Skin Showcase
+
+This document captures the currently shipped dashboard skins along with quick reference palettes for QA review and storytelling.
+
+## Fortune 100 Steel
+- Executive navy glass with electric revenue pulses.
+- Primary accents: hsl(212 100% 45%), hsl(210 10% 85%), hsl(355 85% 55%).
+
+## Aurora Glass
+- Polar neon glass for data-native operators.
+- Primary accents: hsl(195 86% 62%), hsl(282 78% 68%), hsl(152 72% 48%).
+
+## Ember Vanguard
+- Sunset war room with molten KPI heat.
+- Primary accents: hsl(16 92% 58%), hsl(347 74% 62%), hsl(42 86% 62%).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,30 +14,33 @@ import JourneyBuilder from "./pages/JourneyBuilder";
 import WorkflowManager from "./pages/WorkflowManager";
 import DncUpload from "./pages/DncUpload";
 import NotFound from "./pages/NotFound";
+import { SkinProvider } from "./hooks/useSkin";
 
 const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<Index />} />
-            <Route path="create" element={<CreateCampaign />} />
-            <Route path="campaigns" element={<Campaigns />} />
-            <Route path="flex" element={<FlexManagement />} />
-            <Route path="journeys" element={<JourneyBuilder />} />
-            <Route path="workflows" element={<WorkflowManager />} />
-            <Route path="dnc-upload" element={<DncUpload />} />
-            <Route path="settings" element={<SettingsPage />} />
-          </Route>
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
+    <SkinProvider>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<Index />} />
+              <Route path="create" element={<CreateCampaign />} />
+              <Route path="campaigns" element={<Campaigns />} />
+              <Route path="flex" element={<FlexManagement />} />
+              <Route path="journeys" element={<JourneyBuilder />} />
+              <Route path="workflows" element={<WorkflowManager />} />
+              <Route path="dnc-upload" element={<DncUpload />} />
+              <Route path="settings" element={<SettingsPage />} />
+            </Route>
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </SkinProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { getSupabaseBrowserClient } from "@/lib/supabaseClient";
 import { cn } from "@/lib/utils";
+import SkinSelector from "./SkinSelector";
 
 const BUILD_STATUSES = [
   "queued",
@@ -76,20 +77,26 @@ type UiProject = {
 };
 
 const statusBadgeClass: Record<BuildStatus, string> = {
-  queued: "bg-yellow-500/80 text-background font-semibold",
-  running: "bg-corporate-blue text-white font-semibold",
-  succeeded: "revenue-indicator text-background font-semibold",
-  failed: "bg-corporate-crimson text-white font-semibold",
-  cancelled: "bg-corporate-charcoal text-white font-semibold",
-  unknown: "bg-muted text-foreground font-semibold",
+  queued:
+    "border border-amber-200 bg-amber-50 text-amber-700 shadow-[0_8px_18px_-12px_rgba(217,119,6,0.45)]",
+  running:
+    "border border-blue-300 bg-gradient-to-tr from-blue-500 via-blue-600 to-blue-500 text-white shadow-[0_12px_28px_-18px_rgba(37,99,235,0.55)]",
+  succeeded:
+    "border border-emerald-300 bg-gradient-to-tr from-emerald-500 via-emerald-400 to-emerald-500 text-white shadow-[0_12px_28px_-18px_rgba(16,185,129,0.55)]",
+  failed:
+    "border border-rose-300 bg-gradient-to-tr from-rose-500 via-rose-500 to-rose-600 text-white shadow-[0_12px_28px_-18px_rgba(244,63,94,0.55)]",
+  cancelled:
+    "border border-slate-200 bg-slate-100 text-slate-600 shadow-[0_8px_20px_-16px_rgba(15,23,42,0.25)]",
+  unknown:
+    "border border-slate-200 bg-slate-50 text-slate-500 shadow-[0_6px_18px_-14px_rgba(100,116,139,0.25)]",
 };
 
 const statusDotClass: Record<BuildStatus, string> = {
-  queued: "bg-yellow-400",
-  running: "bg-blue-400",
-  succeeded: "bg-emerald-400",
-  failed: "bg-red-500",
-  cancelled: "bg-slate-500",
+  queued: "bg-amber-500",
+  running: "bg-blue-500",
+  succeeded: "bg-emerald-500",
+  failed: "bg-rose-500",
+  cancelled: "bg-slate-400",
   unknown: "bg-slate-400",
 };
 
@@ -466,17 +473,20 @@ const Dashboard = () => {
           <h1 className="text-4xl font-bold fortune-heading mb-2">REVENUE COMMAND CENTER</h1>
           <p className="text-corporate-silver">Enterprise Marketing Operations • Fortune 100 Class</p>
         </div>
-        <div className="flex items-center gap-4">
-          <Button variant="outline" size="icon" className="glow-corporate" aria-label="Notifications">
-            <Bell className="h-4 w-4" />
-          </Button>
-          <Button variant="outline" size="icon" className="border-corporate-navy" aria-label="Settings">
-            <Settings className="h-4 w-4" />
-          </Button>
-          <Button className="btn-corporate text-white font-semibold">
-            <Plus className="h-4 w-4 mr-2" />
-            Launch Campaign
-          </Button>
+        <div className="flex items-center gap-6">
+          <SkinSelector />
+          <div className="flex items-center gap-4">
+            <Button variant="outline" size="icon" className="glow-corporate" aria-label="Notifications">
+              <Bell className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="icon" className="border-corporate-navy" aria-label="Settings">
+              <Settings className="h-4 w-4" />
+            </Button>
+            <Button className="btn-corporate text-white font-semibold">
+              <Plus className="h-4 w-4 mr-2" />
+              Launch Campaign
+            </Button>
+          </div>
         </div>
       </div>
 

--- a/src/components/SkinSelector.tsx
+++ b/src/components/SkinSelector.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { useSkin } from "@/hooks/useSkin";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { AlertCircle, Check, Loader2, Paintbrush, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SkinId } from "@/lib/skins";
+
+const SkinSelector = () => {
+  const {
+    availableSkins,
+    currentSkinId,
+    currentSkin,
+    selectSkin,
+    isRemoteLoading,
+    pendingSkinId,
+    lastError,
+    isHydrated,
+  } = useSkin();
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = async (skinId: SkinId) => {
+    try {
+      await selectSkin(skinId);
+      setOpen(false);
+    } catch (error) {
+      console.error("Skin selection failed", error);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Popover
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (!isHydrated) {
+            return;
+          }
+          setOpen(nextOpen);
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn(
+              "group relative flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/70 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-slate-500 shadow-[0_12px_32px_-18px_rgba(15,23,42,0.35)] backdrop-blur-xl transition",
+              "hover:border-slate-300 hover:text-slate-800 hover:shadow-[0_16px_36px_-16px_rgba(15,23,42,0.38)]",
+            )}
+            aria-label="Select dashboard skin"
+            aria-busy={!isHydrated || isRemoteLoading}
+            disabled={!isHydrated && isRemoteLoading}
+          >
+            <Paintbrush className="h-3.5 w-3.5 text-primary transition group-hover:text-primary" />
+            <span className="font-semibold normal-case tracking-tight text-slate-700 group-hover:text-slate-900">
+              {isHydrated ? currentSkin.name : "Hydrating skin..."}
+            </span>
+            {(isRemoteLoading || pendingSkinId === currentSkinId || !isHydrated) && (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" aria-hidden />
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          className="w-80 space-y-4 border border-slate-200/80 bg-white/85 p-4 shadow-[0_28px_60px_-36px_rgba(15,23,42,0.55)] backdrop-blur-2xl"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-semibold text-foreground">Dashboard skins</p>
+              <p className="text-xs text-muted-foreground">
+                Swap live palettes and liquid glass templates.
+              </p>
+            </div>
+            <Sparkles className="h-4 w-4 text-primary" aria-hidden />
+          </div>
+          <div className="grid gap-3">
+            {availableSkins.map((skin) => {
+              const isActive = skin.id === currentSkinId;
+              const isSaving = pendingSkinId === skin.id;
+              return (
+                <button
+                  key={skin.id}
+                  type="button"
+                  onClick={() => handleSelect(skin.id)}
+                  disabled={isSaving}
+                  className={cn(
+                    "relative overflow-hidden rounded-xl border border-slate-200/70 bg-white/70 p-3 text-left shadow-[0_18px_38px_-28px_rgba(15,23,42,0.4)] transition backdrop-blur-xl",
+                    "hover:border-slate-300 hover:shadow-[0_20px_44px_-28px_rgba(15,23,42,0.45)]",
+                    isActive && "border-primary/70 shadow-[0_20px_48px_-28px_rgba(37,99,235,0.45)] ring-2 ring-primary/60",
+                    isSaving && "opacity-80",
+                  )}
+                >
+                  <div
+                    className="pointer-events-none absolute inset-0 opacity-60"
+                    style={{ background: skin.heroGradient }}
+                  />
+                  <div className="relative flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900">{skin.name}</p>
+                      <p className="text-xs text-slate-500">{skin.description}</p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {isSaving && <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" aria-hidden />}
+                      {isActive && (
+                        <Badge
+                          variant="secondary"
+                          className="flex items-center gap-1 border-0 bg-primary/20 text-[0.6rem] uppercase tracking-[0.25em] text-primary"
+                        >
+                          <Check className="h-3 w-3" /> Active
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                  <div className="relative mt-3 flex gap-2">
+                    {skin.previewColors.map((color, index) => (
+                      <span
+                        key={`${skin.id}-preview-${index}`}
+                        className="h-6 flex-1 rounded-full border border-white/25 shadow-inner"
+                        style={{ background: color }}
+                      />
+                    ))}
+                  </div>
+                  <p className="relative mt-3 text-[0.6rem] uppercase tracking-[0.3em] text-slate-500">
+                    {skin.headline}
+                  </p>
+                </button>
+              );
+            })}
+          </div>
+          {lastError && (
+            <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+              <AlertCircle className="mt-[2px] h-3.5 w-3.5" />
+              <span>{lastError}</span>
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+      <span className="text-[0.55rem] uppercase tracking-[0.32em] text-slate-500">Skin</span>
+    </div>
+  );
+};
+
+export default SkinSelector;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,25 +5,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-semibold tracking-tight ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "btn-liquid btn-liquid--primary border-0 px-6 py-2",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "btn-liquid btn-liquid--danger border-0 px-6 py-2",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-border/80 bg-white/65 px-6 py-2 text-foreground shadow-sm backdrop-blur hover:bg-white",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "btn-liquid btn-liquid--success border-0 px-6 py-2",
+        ghost:
+          "px-4 py-2 text-muted-foreground hover:text-foreground hover:bg-muted/60",
+        link: "px-1 text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "h-11 px-5",
+        sm: "h-9 rounded-lg px-4 text-xs",
+        lg: "h-12 rounded-2xl px-8 text-base",
+        icon: "h-11 w-11 rounded-xl",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "glass-panel text-card-foreground",
       className
     )}
     {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,10 +1,10 @@
-import * as React from "react"
-import { type DialogProps } from "@radix-ui/react-dialog"
-import { Command as CommandPrimitive } from "cmdk"
-import { Search } from "lucide-react"
+import * as React from "react";
+import { type DialogProps } from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
 
-import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { cn } from "@/lib/utils";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -14,17 +14,14 @@ const Command = React.forwardRef<
     ref={ref}
     className={cn(
       "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
-      className
+      className,
     )}
     {...props}
   />
-))
-Command.displayName = CommandPrimitive.displayName
-codex/review-war-machine-ui-and-recommend-improvements
+));
+Command.displayName = CommandPrimitive.displayName;
+
 type CommandDialogProps = DialogProps;
-=======
-type CommandDialogProps = DialogProps
-main
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
@@ -35,27 +32,26 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
         </Command>
       </DialogContent>
     </Dialog>
-  )
-}
+  );
+};
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper>
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
         "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
   </div>
-))
-
-CommandInput.displayName = CommandPrimitive.Input.displayName
+));
+CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 const CommandList = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.List>,
@@ -66,9 +62,8 @@ const CommandList = React.forwardRef<
     className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
-))
-
-CommandList.displayName = CommandPrimitive.List.displayName
+));
+CommandList.displayName = CommandPrimitive.List.displayName;
 
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
@@ -79,9 +74,8 @@ const CommandEmpty = React.forwardRef<
     className="py-6 text-center text-sm"
     {...props}
   />
-))
-
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+));
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
 const CommandGroup = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Group>,
@@ -91,13 +85,12 @@ const CommandGroup = React.forwardRef<
     ref={ref}
     className={cn(
       "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
-      className
+      className,
     )}
     {...props}
   />
-))
-
-CommandGroup.displayName = CommandPrimitive.Group.displayName
+));
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
 const CommandSeparator = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Separator>,
@@ -108,8 +101,8 @@ const CommandSeparator = React.forwardRef<
     className={cn("-mx-1 h-px bg-border", className)}
     {...props}
   />
-))
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
@@ -118,39 +111,32 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
-      className
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground",
+      className,
     )}
     {...props}
   />
-))
+));
+CommandItem.displayName = CommandPrimitive.Item.displayName;
 
-CommandItem.displayName = CommandPrimitive.Item.displayName
-
-const CommandShortcut = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
+const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
-        className
-      )}
+      className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
       {...props}
     />
-  )
-}
-CommandShortcut.displayName = "CommandShortcut"
+  );
+};
+CommandShortcut.displayName = "CommandShortcut";
 
 export {
   Command,
   CommandDialog,
-  CommandInput,
-  CommandList,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
-  CommandShortcut,
+  CommandList,
   CommandSeparator,
-}
+  CommandShortcut,
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,28 +1,21 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-codex/review-war-machine-ui-and-recommend-improvements
-export type TextareaProps =
-  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
-=======
-export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
-main
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Textarea.displayName = "Textarea"
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Textarea.displayName = "Textarea";
 
-export { Textarea }
+export { Textarea };

--- a/src/hooks/useSkin.tsx
+++ b/src/hooks/useSkin.tsx
@@ -1,0 +1,178 @@
+import {
+  applySkin,
+  defaultSkinId,
+  getAvailableSkins,
+  getSkin,
+  resolveSkinId,
+  type SkinDefinition,
+  type SkinId,
+} from "@/lib/skins";
+import {
+  fetchRemoteSkin,
+  persistRemoteSkin,
+  persistStoredSkin,
+  readStoredSkin,
+  subscribeToStoredSkin,
+} from "@/lib/preferences";
+import { getSupabaseBrowserClient } from "@/lib/supabaseClient";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
+
+interface SkinContextValue {
+  availableSkins: readonly SkinDefinition[];
+  currentSkinId: SkinId;
+  currentSkin: SkinDefinition;
+  isHydrated: boolean;
+  isRemoteLoading: boolean;
+  pendingSkinId: SkinId | null;
+  lastError: string | null;
+  selectSkin: (skinId: SkinId) => Promise<void>;
+}
+
+const SkinContext = createContext<SkinContextValue | undefined>(undefined);
+
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+function applyToDocument(skinId: SkinId) {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const root = document.documentElement;
+  applySkin(root, getSkin(skinId));
+}
+
+export const SkinProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const availableSkins = useMemo(() => getAvailableSkins(), []);
+  const [currentSkinId, setCurrentSkinId] = useState<SkinId>(() => {
+    const storedSkin = readStoredSkin();
+    const datasetSkin =
+      typeof document !== "undefined" ? document.documentElement.dataset.skin ?? null : null;
+
+    return resolveSkinId(storedSkin ?? datasetSkin ?? defaultSkinId);
+  });
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [isRemoteLoading, setIsRemoteLoading] = useState(false);
+  const [pendingSkinId, setPendingSkinId] = useState<SkinId | null>(null);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    applyToDocument(currentSkinId);
+  }, [currentSkinId]);
+
+  useEffect(() => {
+    persistStoredSkin(currentSkinId);
+  }, [currentSkinId]);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    return subscribeToStoredSkin((skinId) => {
+      const resolved = resolveSkinId(skinId ?? defaultSkinId);
+      setCurrentSkinId((current) => (current === resolved ? current : resolved));
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsRemoteLoading(true);
+
+    fetchRemoteSkin(supabase)
+      .then((remoteSkin) => {
+        if (cancelled || !remoteSkin) {
+          return;
+        }
+        setCurrentSkinId((current) => (current === remoteSkin ? current : remoteSkin));
+        setLastError(null);
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        console.error("Failed to hydrate skin preference from Supabase", error);
+        setLastError(
+          error instanceof Error ? error.message : "Unable to load skin preference from Supabase",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsRemoteLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase]);
+
+  const selectSkin = useCallback(
+    async (skinId: SkinId) => {
+      const resolved = resolveSkinId(skinId);
+      setCurrentSkinId((current) => (current === resolved ? current : resolved));
+      setLastError(null);
+
+      if (!supabase) {
+        return;
+      }
+
+      setPendingSkinId(resolved);
+      try {
+        await persistRemoteSkin(supabase, resolved);
+        setLastError(null);
+      } catch (error) {
+        console.error("Failed to persist skin preference", error);
+        const message = error instanceof Error ? error.message : "Unable to save skin preference";
+        setLastError(message);
+        throw error instanceof Error ? error : new Error(message);
+      } finally {
+        setPendingSkinId((current) => (current === resolved ? null : current));
+      }
+    },
+    [supabase],
+  );
+
+  const value = useMemo<SkinContextValue>(
+    () => ({
+      availableSkins,
+      currentSkinId,
+      currentSkin: getSkin(currentSkinId),
+      isHydrated,
+      isRemoteLoading,
+      pendingSkinId,
+      lastError,
+      selectSkin,
+    }),
+    [
+      availableSkins,
+      currentSkinId,
+      isHydrated,
+      isRemoteLoading,
+      pendingSkinId,
+      lastError,
+      selectSkin,
+    ],
+  );
+
+  return <SkinContext.Provider value={value}>{children}</SkinContext.Provider>;
+};
+
+export function useSkin(): SkinContextValue {
+  const context = useContext(SkinContext);
+  if (!context) {
+    throw new Error("useSkin must be used within a SkinProvider");
+  }
+  return context;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,62 +3,64 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Fortune 100 Corporate War Machine Design System */
-
 @layer base {
   :root {
-    --background: 218 23% 4%;
-    --foreground: 210 40% 95%;
+    --background: 210 40% 98%;
+    --foreground: 215 32% 14%;
 
-    --card: 218 23% 6%;
-    --card-foreground: 210 40% 95%;
+    --card: 0 0% 100%;
+    --card-foreground: 215 32% 14%;
 
-    --popover: 218 23% 6%;
-    --popover-foreground: 210 40% 95%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 215 32% 14%;
 
-    --primary: 212 100% 45%;
-    --primary-foreground: 218 23% 4%;
+    --primary: 213 90% 56%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 218 23% 8%;
-    --secondary-foreground: 210 40% 95%;
+    --secondary: 152 76% 45%;
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 218 23% 10%;
-    --muted-foreground: 210 20% 65%;
+    --muted: 210 16% 92%;
+    --muted-foreground: 215 20% 36%;
 
-    --accent: 14 90% 55%;
-    --accent-foreground: 218 23% 4%;
+    --accent: 189 70% 62%;
+    --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 75% 60%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 72% 56%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 218 23% 12%;
-    --input: 218 23% 8%;
-    --ring: 212 100% 45%;
+    --border: 210 24% 88%;
+    --input: 210 24% 88%;
+    --ring: 213 90% 56%;
 
-    --radius: 0.25rem;
+    --radius: 0.95rem;
 
-    --sidebar-background: 218 23% 3%;
-    --sidebar-foreground: 210 40% 95%;
-    --sidebar-primary: 212 100% 45%;
-    --sidebar-primary-foreground: 218 23% 4%;
-    --sidebar-accent: 218 23% 7%;
-    --sidebar-accent-foreground: 210 40% 95%;
-    --sidebar-border: 218 23% 10%;
-    --sidebar-ring: 212 100% 45%;
+    --sidebar-background: 210 40% 98%;
+    --sidebar-foreground: 215 34% 16%;
+    --sidebar-primary: 213 90% 56%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 189 70% 62%;
+    --sidebar-accent-foreground: 210 40% 15%;
+    --sidebar-border: 210 24% 88%;
+    --sidebar-ring: 213 90% 56%;
 
-    /* Corporate Fortune 100 colors */
-    --corporate-blue: 212 100% 45%;
-    --corporate-navy: 218 50% 20%;
-    --corporate-silver: 210 15% 75%;
-    --corporate-platinum: 210 10% 85%;
-    --corporate-gold: 43 74% 66%;
-    --corporate-crimson: 355 85% 55%;
-    --corporate-emerald: 160 84% 39%;
-    --corporate-charcoal: 218 23% 15%;
-    --revenue-green: 142 71% 45%;
-    --conversion-orange: 25 95% 53%;
-    --kpi-purple: 262 83% 58%;
-    --warning-amber: 45 93% 47%;
+    --glass-base: 210 45% 99%;
+    --glass-highlight: 0 0% 100%;
+    --glass-border: 208 28% 82%;
+    --glass-shadow: 213 46% 52%;
+
+    --corporate-blue: 213 90% 56%;
+    --corporate-navy: 226 40% 28%;
+    --corporate-silver: 210 16% 80%;
+    --corporate-platinum: 204 24% 92%;
+    --corporate-gold: 44 84% 62%;
+    --corporate-crimson: 0 78% 54%;
+    --corporate-emerald: 152 76% 45%;
+    --corporate-charcoal: 215 24% 28%;
+    --revenue-green: 150 80% 40%;
+    --conversion-orange: 28 94% 55%;
+    --kpi-purple: 262 70% 58%;
+    --warning-amber: 44 90% 58%;
   }
 }
 
@@ -68,106 +70,116 @@
   }
 
   body {
-    @apply bg-background text-foreground font-mono;
+    @apply bg-background text-foreground font-sans;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+    background:
+      radial-gradient(circle at 18% 18%, hsla(var(--primary) / 0.16) 0%, transparent 55%),
+      radial-gradient(circle at 80% 0%, hsla(var(--accent) / 0.18) 0%, transparent 50%),
+      radial-gradient(circle at 50% 110%, hsla(var(--secondary) / 0.16) 0%, transparent 58%),
+      hsl(var(--background));
   }
 
-  /* Corporate grid pattern */
-  .corporate-grid {
-    background-image: 
-      linear-gradient(rgba(59, 130, 246, 0.08) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(59, 130, 246, 0.08) 1px, transparent 1px);
-    background-size: 24px 24px;
+  .glass-panel {
+    position: relative;
+    border-radius: var(--radius);
+    background:
+      linear-gradient(135deg,
+        hsla(var(--glass-base) / 0.94) 0%,
+        hsla(var(--glass-highlight) / 0.9) 45%,
+        hsla(var(--glass-base) / 0.86) 100%);
+    border: 1px solid hsla(var(--glass-border) / 0.75);
+    box-shadow:
+      0 24px 48px -28px hsla(var(--glass-shadow) / 0.45),
+      inset 0 1px 0 hsla(0 0% 100% / 0.85);
+    backdrop-filter: blur(22px);
   }
 
-  /* Premium glow effects */
-  .glow-corporate {
-    box-shadow: 0 0 30px rgba(59, 130, 246, 0.15), 0 0 60px rgba(59, 130, 246, 0.1);
+  .glass-panel::before {
+    content: "";
+    position: absolute;
+    inset: 1px 1px auto 1px;
+    height: 40%;
+    border-radius: calc(var(--radius) - 2px);
+    background: linear-gradient(135deg, hsla(0 0% 100% / 0.7), transparent 70%);
+    opacity: 0.9;
+    pointer-events: none;
   }
 
-  .glow-revenue {
-    box-shadow: 0 0 20px rgba(34, 197, 94, 0.3);
+  .glass-panel::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at 20% 20%, hsla(var(--primary) / 0.08), transparent 55%),
+      radial-gradient(circle at 80% 0%, hsla(var(--accent) / 0.08), transparent 55%);
+    mix-blend-mode: soft-light;
+    pointer-events: none;
   }
 
-  .glow-conversion {
-    box-shadow: 0 0 20px rgba(251, 146, 60, 0.3);
+  .metric-card {
+    background:
+      linear-gradient(135deg,
+        hsla(var(--glass-base) / 0.92) 0%,
+        hsla(var(--glass-highlight) / 0.88) 100%);
+    border: 1px solid hsla(var(--glass-border) / 0.75);
+    box-shadow:
+      0 18px 44px -28px hsla(var(--glass-shadow) / 0.45),
+      inset 0 1px 0 hsla(0 0% 100% / 0.65);
+    backdrop-filter: blur(20px);
   }
 
-  .glow-premium {
-    box-shadow: 
-      0 0 20px rgba(59, 130, 246, 0.2),
-      0 0 40px rgba(59, 130, 246, 0.1),
-      inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  }
-
-  /* Corporate pulse animation */
-  .pulse-corporate {
-    animation: pulse-corporate 3s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-  }
-
-  @keyframes pulse-corporate {
-    0%, 100% {
-      box-shadow: 
-        0 0 20px rgba(59, 130, 246, 0.2),
-        0 0 40px rgba(59, 130, 246, 0.1);
-    }
-    50% {
-      box-shadow: 
-        0 0 30px rgba(59, 130, 246, 0.4),
-        0 0 60px rgba(59, 130, 246, 0.2);
-    }
-  }
-
-  /* Revenue tracking styles */
   .revenue-indicator {
-    background: linear-gradient(135deg, 
-      hsl(var(--revenue-green)) 0%, 
-      hsl(var(--corporate-emerald)) 100%);
+    background: linear-gradient(135deg,
+      hsl(var(--revenue-green)) 0%,
+      hsl(var(--secondary)) 100%);
+    box-shadow: 0 12px 24px -12px rgba(34, 197, 94, 0.35);
   }
 
   .conversion-indicator {
-    background: linear-gradient(135deg, 
-      hsl(var(--conversion-orange)) 0%, 
+    background: linear-gradient(135deg,
+      hsl(var(--conversion-orange)) 0%,
       hsl(var(--warning-amber)) 100%);
+    box-shadow: 0 12px 24px -12px rgba(251, 146, 60, 0.35);
   }
 
-  /* Executive dashboard styling */
-  .executive-card {
-    background: linear-gradient(135deg, 
-      hsl(var(--card)) 0%, 
-      hsl(var(--corporate-charcoal)) 100%);
-    border: 1px solid hsl(var(--corporate-navy));
+  .btn-liquid {
+    position: relative;
+    overflow: hidden;
+    border-radius: calc(var(--radius) - 0.25rem);
+    transition: transform 200ms ease, box-shadow 200ms ease;
+    box-shadow: 0 16px 36px -18px rgba(17, 24, 39, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.6);
   }
 
-  /* Premium button styles */
-  .btn-corporate {
-    background: linear-gradient(135deg, 
-      hsl(var(--corporate-blue)) 0%, 
-      hsl(var(--corporate-navy)) 100%);
-    border: 1px solid hsl(var(--corporate-silver) / 0.2);
-    box-shadow: 
-      0 4px 16px rgba(59, 130, 246, 0.25),
-      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  .btn-liquid::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.35), transparent 60%);
+    mix-blend-mode: screen;
+    pointer-events: none;
   }
 
-  .btn-corporate:hover {
-    box-shadow: 
-      0 8px 32px rgba(59, 130, 246, 0.35),
-      inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  .btn-liquid:hover {
     transform: translateY(-1px);
+    box-shadow: 0 18px 40px -18px rgba(17, 24, 39, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.7);
   }
 
-  /* Fortune 100 typography */
-  .fortune-heading {
-    background: linear-gradient(135deg, 
-      hsl(var(--corporate-platinum)) 0%, 
-      hsl(var(--corporate-silver)) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  .btn-liquid--primary {
+    background: linear-gradient(135deg, hsl(var(--primary)) 0%, hsla(var(--primary) / 0.82) 100%);
+    color: hsl(var(--primary-foreground));
   }
 
-  /* KPI indicators */
+  .btn-liquid--success {
+    background: linear-gradient(135deg, hsl(var(--secondary)) 0%, hsla(var(--secondary) / 0.78) 100%);
+    color: hsl(var(--secondary-foreground));
+  }
+
+  .btn-liquid--danger {
+    background: linear-gradient(135deg, hsl(var(--destructive)) 0%, hsla(var(--destructive) / 0.76) 100%);
+    color: hsl(var(--destructive-foreground));
+  }
+
   .kpi-positive {
     color: hsl(var(--revenue-green));
   }
@@ -178,14 +190,5 @@
 
   .kpi-neutral {
     color: hsl(var(--conversion-orange));
-  }
-
-  /* Data visualization enhancements */
-  .metric-card {
-    background: linear-gradient(135deg, 
-      hsl(var(--card) / 0.8) 0%, 
-      hsl(var(--corporate-charcoal) / 0.6) 100%);
-    backdrop-filter: blur(16px);
-    border: 1px solid hsl(var(--border) / 0.8);
   }
 }

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -1,0 +1,179 @@
+import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
+import { resolveSkinId, type SkinId } from "./skins";
+
+const STORAGE_KEY = "mwcc:dashboard-skin";
+
+type StorageCallback = (skinId: SkinId | null) => void;
+
+export function readStoredSkin(): SkinId | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+
+    return resolveSkinId(stored);
+  } catch (error) {
+    console.warn("Unable to read skin preference from localStorage", error);
+    return null;
+  }
+}
+
+export function persistStoredSkin(skinId: SkinId) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, skinId);
+  } catch (error) {
+    console.warn("Unable to persist skin preference to localStorage", error);
+  }
+}
+
+export function subscribeToStoredSkin(callback: StorageCallback): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const handler = (event: StorageEvent) => {
+    if (event.key !== STORAGE_KEY) {
+      return;
+    }
+
+    try {
+      callback(event.newValue ? resolveSkinId(event.newValue) : null);
+    } catch (error) {
+      console.warn("Unable to react to skin preference storage change", error);
+      callback(null);
+    }
+  };
+
+  window.addEventListener("storage", handler);
+
+  return () => {
+    window.removeEventListener("storage", handler);
+  };
+}
+
+function isAuthSessionError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  return "message" in error && typeof (error as { message?: unknown }).message === "string"
+    ? (error as { message: string }).message.toLowerCase().includes("session")
+    : false;
+}
+
+function getPostgrestCode(error: unknown): string | null {
+  if (error && typeof error === "object" && "code" in error) {
+    const code = (error as PostgrestError).code;
+    if (typeof code === "string") {
+      return code;
+    }
+  }
+  return null;
+}
+
+function isIgnorablePreferenceError(error: unknown): boolean {
+  const code = getPostgrestCode(error);
+
+  if (!code) {
+    return false;
+  }
+
+  // 42P01: relation does not exist, 42501: insufficient privilege
+  // PGRST116: row not found for maybeSingle, PGRST301: table not found
+  return ["42P01", "42501", "PGRST116", "PGRST301"].includes(code);
+}
+
+function formatSupabaseError(error: unknown, fallback: string): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(fallback);
+}
+
+export async function fetchRemoteSkin(
+  client: SupabaseClient,
+): Promise<SkinId | null> {
+  const {
+    data: { user },
+    error: authError,
+  } = await client.auth.getUser();
+
+  if (authError) {
+    if (isAuthSessionError(authError)) {
+      return null;
+    }
+    throw formatSupabaseError(authError, "Failed to determine current Supabase user");
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  const { data, error } = await client
+    .from("user_preferences")
+    .select("dashboard_skin")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error) {
+    if (isIgnorablePreferenceError(error)) {
+      console.warn("Dashboard skin preference table unavailable, falling back to defaults", error);
+      return null;
+    }
+
+    throw formatSupabaseError(error, "Failed to load dashboard skin preference");
+  }
+
+  const remoteSkin = data?.dashboard_skin as string | null | undefined;
+  if (!remoteSkin) {
+    return null;
+  }
+
+  return resolveSkinId(remoteSkin);
+}
+
+export async function persistRemoteSkin(client: SupabaseClient, skinId: SkinId): Promise<void> {
+  const {
+    data: { user },
+    error: authError,
+  } = await client.auth.getUser();
+
+  if (authError) {
+    if (isAuthSessionError(authError)) {
+      return;
+    }
+    throw formatSupabaseError(authError, "Failed to determine current Supabase user");
+  }
+
+  if (!user) {
+    return;
+  }
+
+  const { error } = await client
+    .from("user_preferences")
+    .upsert(
+      {
+        user_id: user.id,
+        dashboard_skin: skinId,
+      },
+      { onConflict: "user_id" },
+    );
+
+  if (error) {
+    if (isIgnorablePreferenceError(error)) {
+      console.warn("Unable to persist dashboard skin preference remotely; continuing with local value", error);
+      return;
+    }
+
+    throw formatSupabaseError(error, "Failed to persist dashboard skin preference");
+  }
+}

--- a/src/lib/skins.ts
+++ b/src/lib/skins.ts
@@ -1,0 +1,293 @@
+export type SkinDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  cssVars: Record<string, string>;
+  previewColors: readonly string[];
+  heroGradient: string;
+  headline: string;
+};
+
+const liquidGlassTokens: Record<string, string> = {
+  background: "210 40% 98%",
+  foreground: "215 32% 14%",
+  card: "0 0% 100%",
+  "card-foreground": "215 32% 14%",
+  popover: "0 0% 100%",
+  "popover-foreground": "215 32% 14%",
+  primary: "213 90% 56%",
+  "primary-foreground": "0 0% 100%",
+  secondary: "152 76% 45%",
+  "secondary-foreground": "0 0% 100%",
+  muted: "210 16% 92%",
+  "muted-foreground": "215 20% 36%",
+  accent: "189 70% 62%",
+  "accent-foreground": "0 0% 100%",
+  destructive: "0 72% 56%",
+  "destructive-foreground": "0 0% 100%",
+  border: "210 24% 88%",
+  input: "210 24% 88%",
+  ring: "213 90% 56%",
+  radius: "0.95rem",
+  "sidebar-background": "210 40% 98%",
+  "sidebar-foreground": "215 34% 16%",
+  "sidebar-primary": "213 90% 56%",
+  "sidebar-primary-foreground": "0 0% 100%",
+  "sidebar-accent": "189 70% 62%",
+  "sidebar-accent-foreground": "210 40% 15%",
+  "sidebar-border": "210 24% 88%",
+  "sidebar-ring": "213 90% 56%",
+  "glass-base": "210 45% 99%",
+  "glass-highlight": "0 0% 100%",
+  "glass-border": "208 28% 82%",
+  "glass-shadow": "213 46% 52%",
+  "corporate-blue": "213 90% 56%",
+  "corporate-navy": "226 40% 28%",
+  "corporate-silver": "210 16% 80%",
+  "corporate-platinum": "204 24% 92%",
+  "corporate-gold": "44 84% 62%",
+  "corporate-crimson": "0 78% 54%",
+  "corporate-emerald": "152 76% 45%",
+  "corporate-charcoal": "215 24% 28%",
+  "revenue-green": "150 80% 40%",
+  "conversion-orange": "28 94% 55%",
+  "kpi-purple": "262 70% 58%",
+  "warning-amber": "44 90% 58%",
+};
+
+const fortune100Tokens: Record<string, string> = {
+  background: "218 23% 4%",
+  foreground: "210 40% 95%",
+  card: "218 23% 6%",
+  "card-foreground": "210 40% 95%",
+  popover: "218 23% 6%",
+  "popover-foreground": "210 40% 95%",
+  primary: "212 100% 45%",
+  "primary-foreground": "218 23% 4%",
+  secondary: "218 23% 8%",
+  "secondary-foreground": "210 40% 95%",
+  muted: "218 23% 10%",
+  "muted-foreground": "210 20% 65%",
+  accent: "14 90% 55%",
+  "accent-foreground": "218 23% 4%",
+  destructive: "0 75% 60%",
+  "destructive-foreground": "210 40% 98%",
+  border: "218 23% 12%",
+  input: "218 23% 8%",
+  ring: "212 100% 45%",
+  radius: "0.25rem",
+  "sidebar-background": "218 23% 3%",
+  "sidebar-foreground": "210 40% 95%",
+  "sidebar-primary": "212 100% 45%",
+  "sidebar-primary-foreground": "218 23% 4%",
+  "sidebar-accent": "218 23% 7%",
+  "sidebar-accent-foreground": "210 40% 95%",
+  "sidebar-border": "218 23% 10%",
+  "sidebar-ring": "212 100% 45%",
+  "glass-base": "218 28% 10%",
+  "glass-highlight": "210 40% 88%",
+  "glass-border": "218 24% 18%",
+  "glass-shadow": "212 90% 32%",
+  "corporate-blue": "212 100% 45%",
+  "corporate-navy": "218 50% 20%",
+  "corporate-silver": "210 15% 75%",
+  "corporate-platinum": "210 10% 85%",
+  "corporate-gold": "43 74% 66%",
+  "corporate-crimson": "355 85% 55%",
+  "corporate-emerald": "160 84% 39%",
+  "corporate-charcoal": "218 23% 15%",
+  "revenue-green": "142 71% 45%",
+  "conversion-orange": "25 95% 53%",
+  "kpi-purple": "262 83% 58%",
+  "warning-amber": "45 93% 47%",
+};
+
+const auroraGlassTokens: Record<string, string> = {
+  background: "223 54% 6%",
+  foreground: "197 56% 96%",
+  card: "222 48% 12%",
+  "card-foreground": "197 56% 96%",
+  popover: "222 48% 10%",
+  "popover-foreground": "197 56% 96%",
+  primary: "195 86% 62%",
+  "primary-foreground": "218 45% 10%",
+  secondary: "225 36% 18%",
+  "secondary-foreground": "197 56% 96%",
+  muted: "225 34% 22%",
+  "muted-foreground": "197 40% 78%",
+  accent: "282 78% 68%",
+  "accent-foreground": "222 55% 12%",
+  destructive: "356 82% 62%",
+  "destructive-foreground": "197 56% 96%",
+  border: "224 36% 26%",
+  input: "224 36% 20%",
+  ring: "195 86% 62%",
+  radius: "0.65rem",
+  "sidebar-background": "225 48% 8%",
+  "sidebar-foreground": "197 56% 96%",
+  "sidebar-primary": "195 86% 62%",
+  "sidebar-primary-foreground": "220 54% 12%",
+  "sidebar-accent": "282 70% 30%",
+  "sidebar-accent-foreground": "198 48% 92%",
+  "sidebar-border": "225 36% 26%",
+  "sidebar-ring": "195 86% 62%",
+  "glass-base": "223 52% 16%",
+  "glass-highlight": "197 56% 94%",
+  "glass-border": "223 40% 28%",
+  "glass-shadow": "195 70% 48%",
+  "corporate-blue": "195 86% 62%",
+  "corporate-navy": "224 60% 18%",
+  "corporate-silver": "197 28% 74%",
+  "corporate-platinum": "197 32% 85%",
+  "corporate-gold": "45 92% 72%",
+  "corporate-crimson": "351 82% 62%",
+  "corporate-emerald": "154 72% 50%",
+  "corporate-charcoal": "225 40% 22%",
+  "revenue-green": "152 72% 48%",
+  "conversion-orange": "32 88% 58%",
+  "kpi-purple": "275 78% 68%",
+  "warning-amber": "45 94% 56%",
+};
+
+const emberVanguardTokens: Record<string, string> = {
+  background: "24 42% 6%",
+  foreground: "32 40% 94%",
+  card: "24 45% 12%",
+  "card-foreground": "32 40% 94%",
+  popover: "24 45% 10%",
+  "popover-foreground": "32 40% 94%",
+  primary: "16 92% 58%",
+  "primary-foreground": "28 36% 8%",
+  secondary: "32 32% 20%",
+  "secondary-foreground": "32 40% 94%",
+  muted: "32 28% 24%",
+  "muted-foreground": "28 24% 74%",
+  accent: "347 74% 62%",
+  "accent-foreground": "28 36% 8%",
+  destructive: "2 82% 60%",
+  "destructive-foreground": "28 36% 96%",
+  border: "28 32% 26%",
+  input: "28 32% 22%",
+  ring: "16 92% 58%",
+  radius: "0.4rem",
+  "sidebar-background": "24 42% 9%",
+  "sidebar-foreground": "32 40% 94%",
+  "sidebar-primary": "16 92% 58%",
+  "sidebar-primary-foreground": "28 36% 8%",
+  "sidebar-accent": "347 74% 28%",
+  "sidebar-accent-foreground": "28 36% 94%",
+  "sidebar-border": "28 32% 26%",
+  "sidebar-ring": "16 92% 58%",
+  "glass-base": "24 38% 12%",
+  "glass-highlight": "32 40% 92%",
+  "glass-border": "26 34% 24%",
+  "glass-shadow": "16 88% 42%",
+  "corporate-blue": "205 82% 54%",
+  "corporate-navy": "220 50% 20%",
+  "corporate-silver": "35 24% 70%",
+  "corporate-platinum": "35 22% 82%",
+  "corporate-gold": "42 86% 62%",
+  "corporate-crimson": "2 82% 60%",
+  "corporate-emerald": "145 65% 48%",
+  "corporate-charcoal": "24 32% 18%",
+  "revenue-green": "142 64% 46%",
+  "conversion-orange": "28 92% 58%",
+  "kpi-purple": "285 70% 62%",
+  "warning-amber": "40 92% 58%",
+};
+
+const SKIN_DEFINITIONS = [
+  {
+    id: "liquid-glass-pro",
+    name: "Liquid Glass PRO",
+    description: "Crisp white glass with executive neon accents.",
+    cssVars: liquidGlassTokens,
+    previewColors: [
+      "hsl(213 90% 56%)",
+      "hsl(152 76% 45%)",
+      "hsl(0 72% 56%)",
+    ],
+    heroGradient:
+      "linear-gradient(135deg, hsla(213,90%,56%,0.18) 0%, hsla(152,76%,45%,0.12) 45%, hsla(0,0%,100%,0.8) 100%)",
+    headline: "Liquid glass control",
+  },
+  {
+    id: "fortune-100",
+    name: "Fortune 100 Steel",
+    description: "Executive navy glass with electric revenue pulses.",
+    cssVars: fortune100Tokens,
+    previewColors: [
+      "hsl(212 100% 45%)",
+      "hsl(210 10% 85%)",
+      "hsl(355 85% 55%)",
+    ],
+    heroGradient:
+      "linear-gradient(135deg, hsla(212,100%,45%,0.8) 0%, hsla(218,50%,20%,0.9) 50%, hsla(210,10%,85%,0.35) 100%)",
+    headline: "Fortune 100 ready",
+  },
+  {
+    id: "aurora-glass",
+    name: "Aurora Glass",
+    description: "Polar neon glass for data-native operators.",
+    cssVars: auroraGlassTokens,
+    previewColors: [
+      "hsl(195 86% 62%)",
+      "hsl(282 78% 68%)",
+      "hsl(152 72% 48%)",
+    ],
+    heroGradient:
+      "linear-gradient(135deg, hsla(195,86%,62%,0.8) 0%, hsla(282,78%,68%,0.7) 55%, hsla(197,56%,96%,0.35) 100%)",
+    headline: "Neon telemetry",
+  },
+  {
+    id: "ember-vanguard",
+    name: "Ember Vanguard",
+    description: "Sunset war room with molten KPI heat.",
+    cssVars: emberVanguardTokens,
+    previewColors: [
+      "hsl(16 92% 58%)",
+      "hsl(347 74% 62%)",
+      "hsl(42 86% 62%)",
+    ],
+    heroGradient:
+      "linear-gradient(135deg, hsla(16,92%,58%,0.85) 0%, hsla(347,74%,62%,0.75) 50%, hsla(32,40%,94%,0.35) 100%)",
+    headline: "Molten conversions",
+  },
+] as const satisfies readonly SkinDefinition[];
+
+export type SkinId = (typeof SKIN_DEFINITIONS)[number]["id"];
+
+const skinMap = new Map<SkinId, SkinDefinition>(
+  SKIN_DEFINITIONS.map((definition) => [definition.id, definition]),
+);
+
+export const defaultSkinId: SkinId = "liquid-glass-pro";
+
+export function getAvailableSkins(): readonly SkinDefinition[] {
+  return SKIN_DEFINITIONS;
+}
+
+export function getSkin(id: SkinId | string | null | undefined): SkinDefinition {
+  if (!id) {
+    return skinMap.get(defaultSkinId)!;
+  }
+  const skin = skinMap.get(id as SkinId);
+  return skin ?? skinMap.get(defaultSkinId)!;
+}
+
+export function applySkin(target: HTMLElement, skin: SkinDefinition) {
+  const resolved = getSkin(skin.id);
+  const fallbackTokens = skinMap.get(defaultSkinId)!.cssVars;
+  const tokens = { ...fallbackTokens, ...resolved.cssVars };
+
+  Object.entries(tokens).forEach(([token, value]) => {
+    target.style.setProperty(`--${token}`, value);
+  });
+
+  target.dataset.skin = resolved.id;
+}
+
+export function resolveSkinId(value: string | null | undefined): SkinId {
+  const skin = getSkin(value as SkinId | undefined);
+  return skin.id;
+}

--- a/supabase/migrations/20241011130000_user_preferences_skin.sql
+++ b/supabase/migrations/20241011130000_user_preferences_skin.sql
@@ -1,0 +1,51 @@
+-- Persist dashboard skin preferences per authenticated user
+CREATE TABLE IF NOT EXISTS public.user_preferences (
+    user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    dashboard_skin text NOT NULL DEFAULT 'fortune-100',
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    CONSTRAINT user_preferences_skin_allowed CHECK (
+        dashboard_skin = ANY (ARRAY['fortune-100', 'aurora-glass', 'ember-vanguard'])
+    )
+);
+
+COMMENT ON TABLE public.user_preferences IS 'End-user UI preferences keyed to Supabase auth users.';
+COMMENT ON COLUMN public.user_preferences.dashboard_skin IS 'Selected dashboard skin (theme) for the marketing war command center.';
+
+DROP TRIGGER IF EXISTS trg_touch_user_preferences ON public.user_preferences;
+CREATE TRIGGER trg_touch_user_preferences
+    BEFORE UPDATE ON public.user_preferences
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_updated_at();
+
+ALTER TABLE public.user_preferences ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user read own preferences" ON public.user_preferences;
+CREATE POLICY "user read own preferences"
+    ON public.user_preferences
+    FOR SELECT
+    TO authenticated
+    USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "user upsert own preferences" ON public.user_preferences;
+CREATE POLICY "user upsert own preferences"
+    ON public.user_preferences
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "user update own preferences" ON public.user_preferences;
+CREATE POLICY "user update own preferences"
+    ON public.user_preferences
+    FOR UPDATE
+    TO authenticated
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "service role manage user preferences" ON public.user_preferences;
+CREATE POLICY "service role manage user preferences"
+    ON public.user_preferences
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);


### PR DESCRIPTION
## Summary
- introduce a Liquid Glass PRO skin with bright glass tokens and make it the default palette
- refresh the global CSS, cards, buttons, and status chips with white glass surfaces and blue/green/red gradients
- tune the skin selector popover to match the new crisp styling and keep previews vibrant

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2fc23e68832881bea30033b86c8f