### PR TITLE
Restore core UI wiring and resilient financial telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
+        "papaparse": "^5.5.3",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -58,6 +59,7 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.3",
+        "xlsx": "^0.18.5",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -3590,6 +3592,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3829,6 +3840,19 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4287,6 +4311,15 @@
         }
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4320,6 +4353,18 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5055,6 +5100,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -6168,6 +6222,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6909,6 +6969,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -7480,6 +7552,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7597,6 +7687,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
+    "papaparse": "^5.5.3",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
@@ -61,6 +62,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
+    "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,118 +1,31 @@
-
-import { Toaster } from "@/components/ui/toaster";
-import { Toaster as Sonner } from "@/components/ui/sonner";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+
 import Layout from "./components/Layout";
-import Index from "./pages/Index";
-import CreateCampaign from "./pages/CreateCampaign";
-import SettingsPage from "./pages/SettingsPage";
+import { SkinProvider } from "./hooks/useSkin";
 import Campaigns from "./pages/Campaigns";
-import FlexManagement from "./pages/FlexManagement";
-import JourneyBuilder from "./pages/JourneyBuilder";
-import WorkflowManager from "./pages/WorkflowManager";
+import ClientPreviewShowcase from "./pages/ClientPreviewShowcase";
+import CreateCampaign from "./pages/CreateCampaign";
 import DncUpload from "./pages/DncUpload";
 import FinancialsPage from "./pages/Financials";
-import NotFound from "./pages/NotFound";
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
- codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-import TemplateGallery from "./pages/TemplateGallery";
-
-=======
- codex/find-email-templates-for-dental-and-precare-coverage-dftp26
-import TemplateGallery from "./pages/TemplateGallery";
-import ClientPreviewShowcase from "./pages/ClientPreviewShowcase";
-=======
- codex/set-up-dashboard-for-project-overview
-import LeadIntelligence from "./pages/LeadIntelligence";
-import WebDevelopment from "./pages/WebDevelopment";
-=======
- codex/find-email-templates-for-dental-and-precare-coverage-cxc1oz
-import TemplateGallery from "./pages/TemplateGallery";
-=======
-codex/add-skin-selector-for-color-theme
-import { SkinProvider } from "./hooks/useSkin";
-=======
- main
- codex/add-skin-selector-for-color-theme-on40yv
-import { SkinProvider } from "./hooks/useSkin";
-
- codex/define-lead-processing-and-marketing-workflow
+import FlexManagement from "./pages/FlexManagement";
 import GoToMarketPipeline from "./pages/GoToMarketPipeline";
-
-import { SkinProvider } from "./hooks/useSkin";
- main
-main
-main
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-=======
- main
- main
-main
- main
+import Index from "./pages/Index";
+import JourneyBuilder from "./pages/JourneyBuilder";
+import LeadIntelligence from "./pages/LeadIntelligence";
+import NotFound from "./pages/NotFound";
+import SettingsPage from "./pages/SettingsPage";
+import TemplateGallery from "./pages/TemplateGallery";
+import WebDevelopment from "./pages/WebDevelopment";
+import WorkflowManager from "./pages/WorkflowManager";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { Toaster } from "@/components/ui/toaster";
+import { Toaster as Sonner } from "@/components/ui/sonner";
 
 const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-codex/add-skin-selector-for-color-theme
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-=======
-codex/define-lead-processing-and-marketing-workflow
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<Index />} />
-            <Route path="create" element={<CreateCampaign />} />
-            <Route path="campaigns" element={<Campaigns />} />
-            <Route path="flex" element={<FlexManagement />} />
-            <Route path="journeys" element={<JourneyBuilder />} />
-            <Route path="war-map" element={<GoToMarketPipeline />} />
-            <Route path="workflows" element={<WorkflowManager />} />
-codex/set-up-dashboard-for-project-overview
-            <Route path="leads" element={<LeadIntelligence />} />
-            <Route path="web-dev" element={<WebDevelopment />} />
-=======
- codex/integrate-revenue-and-expense-tabs-qmhblg
-            <Route path="dnc-upload" element={<DncUpload />} />
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
- codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-            <Route path="templates" element={<TemplateGallery />} />
-
-=======
- codex/find-email-templates-for-dental-and-precare-coverage-dftp26
-            <Route path="templates" element={<TemplateGallery />} />
-            <Route path="client-previews" element={<ClientPreviewShowcase />} />
-=======
-codex/find-email-templates-for-dental-and-precare-coverage-cxc1oz
-            <Route path="templates" element={<TemplateGallery />} />
-=======
-main
-            <Route path="financials" element={<FinancialsPage />} />
- codex/integrate-revenue-and-expense-tabs-ugnmqm
-
- main
-main
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-=======
-main
- main
- main
- main
-            <Route path="settings" element={<SettingsPage />} />
-          </Route>
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-=======
-main
-main
     <SkinProvider>
       <TooltipProvider>
         <Toaster />
@@ -125,8 +38,14 @@ main
               <Route path="campaigns" element={<Campaigns />} />
               <Route path="flex" element={<FlexManagement />} />
               <Route path="journeys" element={<JourneyBuilder />} />
+              <Route path="war-map" element={<GoToMarketPipeline />} />
               <Route path="workflows" element={<WorkflowManager />} />
+              <Route path="leads" element={<LeadIntelligence />} />
+              <Route path="web-dev" element={<WebDevelopment />} />
               <Route path="dnc-upload" element={<DncUpload />} />
+              <Route path="templates" element={<TemplateGallery />} />
+              <Route path="client-previews" element={<ClientPreviewShowcase />} />
+              <Route path="financials" element={<FinancialsPage />} />
               <Route path="settings" element={<SettingsPage />} />
             </Route>
             <Route path="*" element={<NotFound />} />
@@ -134,13 +53,6 @@ main
         </BrowserRouter>
       </TooltipProvider>
     </SkinProvider>
-codex/add-skin-selector-for-color-theme
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-
-main
-main
-main
   </QueryClientProvider>
 );
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,84 +1,68 @@
-
-import React from 'react';
-import { NavLink } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import React from "react";
+import { NavLink } from "react-router-dom";
 import {
-  Settings,
-  Plus,
-  LayoutDashboard,
-  Target,
-  Users,
-  BarChart3,
-  Phone,
-  FileText,
-  AlertTriangle,
   Activity,
- codex/set-up-dashboard-for-project-overview
+  AlertTriangle,
+  BarChart3,
+  Database,
+  FileText,
   Globe,
-  Database
-=======
- codex/integrate-revenue-and-expense-tabs-ugnmqm
+  LayoutDashboard,
+  MessageSquare,
+  Phone,
+  Plus,
+  Radar,
+  Settings,
+  Target,
   Upload,
-  Coins
-codex/integrate-revenue-and-expense-tabs-qmhblg
-  Upload,
-  Coins
-codex/define-lead-processing-and-marketing-workflow
-  Radar
-  Upload
- main
- main
- main
- main
-} from 'lucide-react';
+  Users,
+  Wallet,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 
 const Sidebar = () => {
   const navItems = [
-    { name: 'Revenue Dashboard', path: '/', icon: LayoutDashboard, badge: null },
-    { name: 'Financial Command', path: '/financials', icon: Coins, badge: 'New' },
-    { name: 'Campaign Operations', path: '/campaigns', icon: Target, badge: '3 Active' },
-    { name: 'Go-To-Market War Map', path: '/war-map', icon: Radar, badge: null },
-    { name: 'Launch Campaign', path: '/create', icon: Plus, badge: null },
-    { name: 'DNC Upload', path: '/dnc-upload', icon: Upload, badge: null },
-    { name: 'Customer Database', path: '/contacts', icon: Users, badge: '47K' },
-    { name: 'Lead Intelligence', path: '/leads', icon: Database, badge: 'Ingest' },
-    { name: 'Performance Analytics', path: '/analytics', icon: BarChart3, badge: null },
-    { name: 'Communication Assets', path: '/numbers', icon: Phone, badge: '12' },
-    { name: 'Message Templates', path: '/templates', icon: FileText, badge: '24' },
- codex/find-email-templates-for-dental-and-precare-coverage-dftp26
-    { name: 'Client Previews', path: '/client-previews', icon: MessageSquare, badge: 'New' },
-=======
-    { name: 'Landing & Web Dev', path: '/web-dev', icon: Globe, badge: null },
-main
-    { name: 'System Configuration', path: '/settings', icon: Settings, badge: null },
-  ];
+    { name: "Revenue Dashboard", path: "/", icon: LayoutDashboard, badge: null },
+    { name: "Financial Command", path: "/financials", icon: Wallet, badge: "Live" },
+    { name: "Campaign Operations", path: "/campaigns", icon: Target, badge: "3 Active" },
+    { name: "Go-To-Market War Map", path: "/war-map", icon: Radar, badge: null },
+    { name: "Launch Campaign", path: "/create", icon: Plus, badge: null },
+    { name: "DNC Upload", path: "/dnc-upload", icon: Upload, badge: null },
+    { name: "Customer Database", path: "/contacts", icon: Users, badge: "47K" },
+    { name: "Lead Intelligence", path: "/leads", icon: Database, badge: "Ingest" },
+    { name: "Performance Analytics", path: "/analytics", icon: BarChart3, badge: null },
+    { name: "Communication Assets", path: "/numbers", icon: Phone, badge: "12" },
+    { name: "Message Templates", path: "/templates", icon: FileText, badge: "24" },
+    { name: "Client Previews", path: "/client-previews", icon: MessageSquare, badge: "New" },
+    { name: "Landing & Web Dev", path: "/web-dev", icon: Globe, badge: null },
+    { name: "System Configuration", path: "/settings", icon: Settings, badge: null },
+  ] as const;
 
   const quickStats = [
-    { label: 'Revenue Generated', value: '$2.4M', color: 'text-revenue-green' },
-    { label: 'Active Operations', value: '12', color: 'text-corporate-blue' },
-    { label: 'Queue Processing', value: '847', color: 'text-warning-amber' },
-    { label: 'System Alerts', value: '2', color: 'text-corporate-crimson' },
+    { label: "Revenue Generated", value: "$2.4M", color: "text-revenue-green" },
+    { label: "Active Operations", value: "12", color: "text-corporate-blue" },
+    { label: "Queue Processing", value: "847", color: "text-warning-amber" },
+    { label: "System Alerts", value: "2", color: "text-corporate-crimson" },
   ];
 
   return (
-    <div className="w-72 h-screen bg-sidebar border-r border-sidebar-border p-4 flex flex-col">
-      {/* Corporate Brand */}
-      <div className="mb-8 p-4 bg-corporate-navy/30 rounded-lg border border-corporate-navy">
-        <h1 className="text-xl font-bold fortune-heading mb-1">REVENUE ENGINE</h1>
+    <div className="flex h-screen w-72 flex-col border-r border-sidebar-border bg-sidebar p-4">
+      <div className="mb-8 rounded-lg border border-corporate-navy bg-corporate-navy/30 p-4">
+        <h1 className="fortune-heading mb-1 text-xl font-bold">REVENUE ENGINE</h1>
         <p className="text-xs text-corporate-silver">Enterprise Command Center</p>
-        <div className="flex items-center gap-2 mt-2">
+        <div className="mt-2 flex items-center gap-2">
           <Activity className="h-3 w-3 text-revenue-green" />
           <span className="text-xs text-corporate-silver">Systems Operational</span>
         </div>
       </div>
 
-      {/* Executive Metrics */}
-      <div className="mb-6 p-4 metric-card rounded-lg border-corporate-charcoal">
-        <h3 className="text-sm font-semibold mb-3 text-corporate-platinum">Executive Metrics</h3>
+      <div className="metric-card mb-6 rounded-lg border-corporate-charcoal p-4">
+        <h3 className="mb-3 text-sm font-semibold text-corporate-platinum">Executive Metrics</h3>
         <div className="space-y-3">
           {quickStats.map((stat) => (
-            <div key={stat.label} className="flex justify-between items-center">
+            <div key={stat.label} className="flex items-center justify-between">
               <span className="text-xs text-corporate-silver">{stat.label}</span>
               <span className={`text-sm font-bold ${stat.color}`}>{stat.value}</span>
             </div>
@@ -86,7 +70,6 @@ main
         </div>
       </div>
 
-      {/* Navigation */}
       <nav className="flex-1">
         <div className="space-y-2">
           {navItems.map((item) => (
@@ -94,19 +77,19 @@ main
               key={item.name}
               to={item.path}
               className={({ isActive }) =>
-                `flex items-center gap-3 px-4 py-3 rounded-lg text-sm transition-all duration-200 ${
+                `flex items-center gap-3 rounded-lg px-4 py-3 text-sm transition-all duration-200 ${
                   isActive
-                    ? 'bg-corporate-blue text-white font-semibold glow-corporate'
-                    : 'text-corporate-silver hover:bg-corporate-charcoal hover:text-corporate-platinum'
+                    ? "bg-corporate-blue text-white font-semibold glow-corporate"
+                    : "text-corporate-silver hover:bg-corporate-charcoal hover:text-corporate-platinum"
                 }`
               }
             >
               <item.icon className="h-4 w-4" />
               <span className="flex-1">{item.name}</span>
               {item.badge && (
-                <Badge 
-                  variant="secondary" 
-                  className="text-xs bg-corporate-navy text-corporate-platinum font-semibold"
+                <Badge
+                  variant="secondary"
+                  className="text-xs font-semibold text-corporate-platinum"
                 >
                   {item.badge}
                 </Badge>
@@ -116,26 +99,24 @@ main
         </div>
       </nav>
 
-      {/* Critical System Controls */}
-      <div className="mt-6 p-4 bg-corporate-crimson/10 border border-corporate-crimson/30 rounded-lg">
-        <h4 className="text-sm font-semibold text-corporate-crimson mb-3 flex items-center gap-2">
+      <div className="mt-6 rounded-lg border border-corporate-crimson/30 bg-corporate-crimson/10 p-4">
+        <h4 className="mb-3 flex items-center gap-2 text-sm font-semibold text-corporate-crimson">
           <AlertTriangle className="h-4 w-4" />
           Critical Controls
         </h4>
-        <Button 
-          variant="destructive" 
-          size="sm" 
-          className="w-full bg-corporate-crimson hover:bg-corporate-crimson/90 text-white font-semibold"
+        <Button
+          variant="destructive"
+          size="sm"
+          className="w-full bg-corporate-crimson font-semibold text-white hover:bg-corporate-crimson/90"
         >
           Emergency Stop All
         </Button>
       </div>
 
-      {/* System Status */}
-      <div className="mt-4 flex items-center gap-2 text-xs p-3 bg-revenue-green/10 rounded-lg border border-revenue-green/30">
-        <Activity className="h-3 w-3 text-revenue-green animate-pulse" />
-        <span className="text-corporate-silver">All Systems: </span>
-        <span className="text-revenue-green font-semibold">OPERATIONAL</span>
+      <div className="mt-4 flex items-center gap-2 rounded-lg border border-revenue-green/30 bg-revenue-green/10 p-3 text-xs">
+        <Activity className="h-3 w-3 animate-pulse text-revenue-green" />
+        <span className="text-corporate-silver">All Systems:</span>
+        <span className="font-semibold text-revenue-green">OPERATIONAL</span>
       </div>
     </div>
   );

--- a/src/components/SkinSelector.tsx
+++ b/src/components/SkinSelector.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
+import { AlertCircle, Check, Loader2, Paintbrush, Sparkles } from "lucide-react";
+
 import { useSkin } from "@/hooks/useSkin";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { AlertCircle, Check, Loader2, Paintbrush, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SkinId } from "@/lib/skins";
 
@@ -16,12 +17,10 @@ const SkinSelector = () => {
     isRemoteLoading,
     pendingSkinId,
     lastError,
-codex/add-skin-selector-for-color-theme
-=======
     isHydrated,
-main
   } = useSkin();
   const [open, setOpen] = useState(false);
+  const isBusy = !isHydrated || isRemoteLoading || pendingSkinId === currentSkinId;
 
   const handleSelect = async (skinId: SkinId) => {
     try {
@@ -34,9 +33,6 @@ main
 
   return (
     <div className="flex flex-col items-end gap-1">
-codex/add-skin-selector-for-color-theme
-      <Popover open={open} onOpenChange={setOpen}>
-=======
       <Popover
         open={open}
         onOpenChange={(nextOpen) => {
@@ -46,68 +42,33 @@ codex/add-skin-selector-for-color-theme
           setOpen(nextOpen);
         }}
       >
-main
         <PopoverTrigger asChild>
           <Button
             variant="outline"
             size="sm"
             className={cn(
-codex/add-skin-selector-for-color-theme
               "group relative flex items-center gap-2 rounded-full border border-white/15 bg-background/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground backdrop-blur-md transition",
               "hover:border-white/35 hover:text-foreground",
             )}
             aria-label="Select dashboard skin"
-          >
-            <Paintbrush className="h-3.5 w-3.5 text-primary transition group-hover:text-primary" />
-            <span className="font-semibold normal-case tracking-tight text-foreground/90 group-hover:text-foreground">
-              {currentSkin.name}
-            </span>
-            {(isRemoteLoading || pendingSkinId === currentSkinId) && (
-=======
-codex/add-skin-selector-for-color-theme-on40yv
-              "group relative flex items-center gap-2 rounded-full border border-white/15 bg-background/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground backdrop-blur-md transition",
-              "hover:border-white/35 hover:text-foreground",
-=======
-              "group relative flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/70 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-slate-500 shadow-[0_12px_32px_-18px_rgba(15,23,42,0.35)] backdrop-blur-xl transition",
-              "hover:border-slate-300 hover:text-slate-800 hover:shadow-[0_16px_36px_-16px_rgba(15,23,42,0.38)]",
- main
-            )}
-            aria-label="Select dashboard skin"
-            aria-busy={!isHydrated || isRemoteLoading}
+            aria-busy={isBusy}
             disabled={!isHydrated && isRemoteLoading}
           >
             <Paintbrush className="h-3.5 w-3.5 text-primary transition group-hover:text-primary" />
- codex/add-skin-selector-for-color-theme-on40yv
             <span className="font-semibold normal-case tracking-tight text-foreground/90 group-hover:text-foreground">
-=======
-            <span className="font-semibold normal-case tracking-tight text-slate-700 group-hover:text-slate-900">
- main
               {isHydrated ? currentSkin.name : "Hydrating skin..."}
             </span>
-            {(isRemoteLoading || pendingSkinId === currentSkinId || !isHydrated) && (
-main
-              <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" aria-hidden />
-            )}
+            {isBusy && <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" aria-hidden />}
           </Button>
         </PopoverTrigger>
         <PopoverContent
           align="end"
-codex/add-skin-selector-for-color-theme
           className="w-80 space-y-4 border border-white/12 bg-background/95 p-4 shadow-xl backdrop-blur-2xl"
-=======
-codex/add-skin-selector-for-color-theme-on40yv
-          className="w-80 space-y-4 border border-white/12 bg-background/95 p-4 shadow-xl backdrop-blur-2xl"
-=======
-          className="w-80 space-y-4 border border-slate-200/80 bg-white/85 p-4 shadow-[0_28px_60px_-36px_rgba(15,23,42,0.55)] backdrop-blur-2xl"
- main
-main
         >
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-semibold text-foreground">Dashboard skins</p>
-              <p className="text-xs text-muted-foreground">
-                Swap live palettes and liquid glass templates.
-              </p>
+              <p className="text-xs text-muted-foreground">Swap live palettes and liquid glass templates.</p>
             </div>
             <Sparkles className="h-4 w-4 text-primary" aria-hidden />
           </div>
@@ -115,6 +76,7 @@ main
             {availableSkins.map((skin) => {
               const isActive = skin.id === currentSkinId;
               const isSaving = pendingSkinId === skin.id;
+
               return (
                 <button
                   key={skin.id}
@@ -122,50 +84,20 @@ main
                   onClick={() => handleSelect(skin.id)}
                   disabled={isSaving}
                   className={cn(
-codex/add-skin-selector-for-color-theme
                     "relative overflow-hidden rounded-xl border border-white/10 bg-background/60 p-3 text-left transition",
                     "hover:border-white/25 hover:shadow-lg",
                     isActive && "border-primary/60 shadow-[0_0_0_1px_rgba(0,0,0,0.35)] ring-2 ring-primary/70",
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-                    "relative overflow-hidden rounded-xl border border-white/10 bg-background/60 p-3 text-left transition",
-                    "hover:border-white/25 hover:shadow-lg",
-                    isActive && "border-primary/60 shadow-[0_0_0_1px_rgba(0,0,0,0.35)] ring-2 ring-primary/70",
-=======
-                    "relative overflow-hidden rounded-xl border border-slate-200/70 bg-white/70 p-3 text-left shadow-[0_18px_38px_-28px_rgba(15,23,42,0.4)] transition backdrop-blur-xl",
-                    "hover:border-slate-300 hover:shadow-[0_20px_44px_-28px_rgba(15,23,42,0.45)]",
-                    isActive && "border-primary/70 shadow-[0_20px_48px_-28px_rgba(37,99,235,0.45)] ring-2 ring-primary/60",
-main
-main
                     isSaving && "opacity-80",
                   )}
                 >
                   <div
-codex/add-skin-selector-for-color-theme
                     className="pointer-events-none absolute inset-0 opacity-40"
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-                    className="pointer-events-none absolute inset-0 opacity-40"
-=======
-                    className="pointer-events-none absolute inset-0 opacity-60"
-main
-main
                     style={{ background: skin.heroGradient }}
                   />
                   <div className="relative flex items-start justify-between gap-3">
                     <div>
-codex/add-skin-selector-for-color-theme
                       <p className="text-sm font-semibold text-foreground">{skin.name}</p>
                       <p className="text-xs text-muted-foreground">{skin.description}</p>
-=======
-codex/add-skin-selector-for-color-theme-on40yv
-                      <p className="text-sm font-semibold text-foreground">{skin.name}</p>
-                      <p className="text-xs text-muted-foreground">{skin.description}</p>
-=======
-                      <p className="text-sm font-semibold text-slate-900">{skin.name}</p>
-                      <p className="text-xs text-slate-500">{skin.description}</p>
-main
-main
                     </div>
                     <div className="flex items-center gap-2">
                       {isSaving && <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" aria-hidden />}
@@ -188,15 +120,7 @@ main
                       />
                     ))}
                   </div>
-codex/add-skin-selector-for-color-theme
                   <p className="relative mt-3 text-[0.6rem] uppercase tracking-[0.3em] text-muted-foreground">
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-                  <p className="relative mt-3 text-[0.6rem] uppercase tracking-[0.3em] text-muted-foreground">
-=======
-                  <p className="relative mt-3 text-[0.6rem] uppercase tracking-[0.3em] text-slate-500">
- main
-main
                     {skin.headline}
                   </p>
                 </button>
@@ -204,30 +128,16 @@ main
             })}
           </div>
           {lastError && (
-codex/add-skin-selector-for-color-theme
-            <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
-=======
-codex/add-skin-selector-for-color-theme-on40yv
-            <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
-=======
-            <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
-main
-main
-              <AlertCircle className="mt-[2px] h-3.5 w-3.5" />
-              <span>{lastError}</span>
+            <div className="flex items-start gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-xs text-destructive">
+              <AlertCircle className="mt-0.5 h-4 w-4" />
+              <p>
+                {lastError}. We kept your local preference and will retry syncing with Supabase on the next
+                change.
+              </p>
             </div>
           )}
         </PopoverContent>
       </Popover>
-codex/add-skin-selector-for-color-theme
-      <span className="text-[0.55rem] uppercase tracking-[0.32em] text-muted-foreground">Skin</span>
-=======
-codex/add-skin-selector-for-color-theme-on40yv
-      <span className="text-[0.55rem] uppercase tracking-[0.32em] text-muted-foreground">Skin</span>
-=======
-      <span className="text-[0.55rem] uppercase tracking-[0.32em] text-slate-500">Skin</span>
-main
-main
     </div>
   );
 };

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -2,27 +2,11 @@ import * as React from "react";
 import { type DialogProps } from "@radix-ui/react-dialog";
 import { Command as CommandPrimitive } from "cmdk";
 import { Search } from "lucide-react";
-codex/add-skin-selector-for-color-theme
-
-import { cn } from "@/lib/utils";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
-=======
-codex/integrate-revenue-and-expense-tabs-ugnmqm
 
 import { cn } from "@/lib/utils";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 
 type CommandDialogProps = DialogProps;
-import { cn } from "@/lib/utils";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
- codex/add-skin-selector-for-color-theme-on40yv
-codex/integrate-revenue-and-expense-tabs-qmhblg
-
-type CommandDialogProps = DialogProps;
- main
-main
-main
-main
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -38,32 +22,16 @@ const Command = React.forwardRef<
   />
 ));
 Command.displayName = CommandPrimitive.displayName;
-codex/add-skin-selector-for-color-theme
 
-type CommandDialogProps = DialogProps;
-=======
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-codex/add-skin-selector-for-color-theme-on40yv
-
-type CommandDialogProps = DialogProps;
-codex/integrate-revenue-and-expense-tabs-qmhblg
-type CommandDialogProps = DialogProps;
- main
-main
-main
-main
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
-  return (
-    <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-          {children}
-        </Command>
-      </DialogContent>
-    </Dialog>
-  );
-};
+const CommandDialog = ({ children, ...props }: CommandDialogProps) => (
+  <Dialog {...props}>
+    <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        {children}
+      </Command>
+    </DialogContent>
+  </Dialog>
+);
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
@@ -99,22 +67,7 @@ const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => (
-codex/integrate-revenue-and-expense-tabs-ugnmqm
   <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
- codex/integrate-revenue-and-expense-tabs-qmhblg
-  <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
-  <CommandPrimitive.Empty
-    ref={ref}
-    className="py-6 text-center text-sm"
-    {...props}
-  />
-codex/add-skin-selector-for-color-theme
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-main
- main
-main
- main
 ));
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
@@ -137,22 +90,7 @@ const CommandSeparator = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-codex/integrate-revenue-and-expense-tabs-ugnmqm
   <CommandPrimitive.Separator ref={ref} className={cn("-mx-1 h-px bg-border", className)} {...props} />
- codex/integrate-revenue-and-expense-tabs-qmhblg
-  <CommandPrimitive.Separator ref={ref} className={cn("-mx-1 h-px bg-border", className)} {...props} />
-  <CommandPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 h-px bg-border", className)}
-    {...props}
-  />
- codex/add-skin-selector-for-color-theme
-=======
-codex/add-skin-selector-for-color-theme-on40yv
- main
- main
-main
- main
 ));
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
@@ -163,25 +101,8 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-codex/add-skin-selector-for-color-theme
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground",
       className,
-=======
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-codex/add-skin-selector-for-color-theme-on40yv
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground",
-      className,
-
- codex/integrate-revenue-and-expense-tabs-qmhblg
-main
-      "relative flex cursor-default select-none items-center rounded-md px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground",
-      className
-
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground",
-      className,
- main
- main
- main
     )}
     {...props}
   />
@@ -189,12 +110,7 @@ main
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
 const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
-      {...props}
-    />
-  );
+  return <span className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)} {...props} />;
 };
 CommandShortcut.displayName = "CommandShortcut";
 

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,81 +1,19 @@
 import * as React from "react";
 
-import { cn } from "@/lib/utils" codex/show-checklist-bar-for-launch-steps
+import { cn } from "@/lib/utils";
+
 export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
-=======
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
-=======
- codex/find-email-templates-for-dental-and-precare-coverage-dftp26
-export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
-=======
- codex/find-email-templates-for-dental-and-precare-coverage-cxc1oz
-export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
-=======
- main
-export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
-codex/add-skin-selector-for-color-theme
-=======
-main
- main
- main
-
-codex/integrate-revenue-and-expense-tabs-ugnmqm
- main
-
-codex/integrate-revenue-and-expense-tabs-qmhblg
-main
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
-  return (
-    <textarea
-      className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-        className
-      )}
-      ref={ref}
-      {...props}
-    />
-  );
-});
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-codex/show-checklist-bar-for-launch-steps
-  ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
-=======
-  ({ className, ...props }, ref) => (
-    <textarea
-      ref={ref}
-      className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-        className,
-      )}
-      {...props}
-    />
-  ),
-);
- codex/add-skin-selector-for-color-theme
-=======
-codex/add-skin-selector-for-color-theme-on40yv
-
- main
- main
-main
- main
- main
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
 Textarea.displayName = "Textarea";
 
 export { Textarea };

--- a/src/features/revenue-expense/FinancialMetricCard.tsx
+++ b/src/features/revenue-expense/FinancialMetricCard.tsx
@@ -1,21 +1,10 @@
 import { ArrowDownRight, ArrowUpRight, Minus } from "lucide-react";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+
 import type { FinancialMetric } from "./useFinancialsData";
 
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-function formatCurrency(value: number) {
-  if (Math.abs(value) >= 1_000_000) {
-    return `$${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (Math.abs(value) >= 1_000) {
-    return `$${(value / 1_000).toFixed(1)}K`;
-  }
-  return `$${value.toLocaleString()}`;
-}
-
-function formatPercent(value: number) {
-  return `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
 function formatCurrency(value: number, precision = 0) {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
@@ -52,7 +41,6 @@ function formatMetricValue(metric: FinancialMetric, value: number) {
     default:
       return formatCurrency(value, precision);
   }
-main
 }
 
 export function FinancialMetricCard({ metric }: { metric: FinancialMetric }) {
@@ -69,39 +57,24 @@ export function FinancialMetricCard({ metric }: { metric: FinancialMetric }) {
   return (
     <Card className="backdrop-blur-xl bg-card/80 border border-white/10 shadow-lg">
       <CardHeader className="pb-2">
-        <CardTitle className="text-sm font-medium text-corporate-platinum">
-          {metric.label}
-        </CardTitle>
+        <CardTitle className="text-sm font-medium text-corporate-platinum">{metric.label}</CardTitle>
       </CardHeader>
       <CardContent className="flex items-end justify-between">
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-        <div>
-          <p className="text-2xl font-semibold text-white">
-            {metric.id === "net-retention" || metric.id === "gross-margin" || metric.id === "unit"
-              ? `${metric.amount.toFixed(1)}%`
-              : metric.id === "sales-cycle"
-              ? `${metric.amount.toFixed(0)} days`
-              : formatCurrency(metric.amount)}
-          </p>
-          {metric.target && (
-            <p className="text-xs text-corporate-silver/70">Target: {formatCurrency(metric.target)}</p>
         <div className="space-y-1">
-          <p className="text-2xl font-semibold text-white">
-            {formatMetricValue(metric, metric.amount)}
-          </p>
+          <p className="text-2xl font-semibold text-white">{formatMetricValue(metric, metric.amount)}</p>
           {metric.target !== undefined && (
             <p className="text-xs text-corporate-silver/70">
               Target: {formatMetricValue(metric, metric.target)}
             </p>
-main
           )}
         </div>
         <div className={cn("flex items-center gap-1 rounded-full px-2 py-1 text-xs", deltaTone)}>
           <TrendIcon className="h-3 w-3" />
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-          <span>{formatPercent(metric.delta)}</span>
-          <span>{formatPercent(metric.delta, metric.delta >= 10 || metric.delta <= -10 ? 0 : 1)}</span>
-main
+          <span>
+            {metric.format === "percent"
+              ? formatPercent(metric.delta, metric.delta >= 10 || metric.delta <= -10 ? 0 : 1)
+              : formatPercent(metric.delta)}
+          </span>
         </div>
       </CardContent>
     </Card>

--- a/src/features/revenue-expense/useFinancialsData.ts
+++ b/src/features/revenue-expense/useFinancialsData.ts
@@ -1,12 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
+import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
+
 import { getSupabaseBrowserClient } from "@/lib/supabaseClient";
 
 export type TrendDirection = "up" | "down" | "flat";
-
- codex/integrate-revenue-and-expense-tabs-ugnmqm
 export type MetricFormat = "currency" | "percent" | "number" | "ratio" | "duration";
 
- main
 export type FinancialMetric = {
   id: string;
   label: string;
@@ -14,21 +13,15 @@ export type FinancialMetric = {
   delta: number;
   trend: TrendDirection;
   target?: number;
- codex/integrate-revenue-and-expense-tabs-ugnmqm
-=======
   format: MetricFormat;
   precision?: number;
   suffix?: string;
- main
 };
 
 export type FinancialRunway = {
   burnRate: number;
   runwayMonths: number;
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-
   cashBalance: number;
- main
   nextMilestone: string;
 };
 
@@ -44,8 +37,6 @@ export type FinancialAlert = {
   message: string;
 };
 
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-=======
 export type RevenueSegment = {
   id: string;
   label: string;
@@ -154,22 +145,25 @@ export type PredictabilityData = {
   voiceSupport: PredictabilitySupportMetric[];
 };
 
->>>> main
+type SupabaseMetricRow = {
+  id: string;
+  label: string;
+  amount?: number | null;
+  delta?: number | null;
+  trend?: string | null;
+  target?: number | null;
+  target_value?: number | null;
+  target_amount?: number | null;
+  format?: string | null;
+  precision?: number | null;
+  decimals?: number | null;
+  suffix?: string | null;
+};
+
 export type FinancialsData = {
   source: "supabase" | "demo";
   lastUpdated: string;
   revenue: {
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-    headline: FinancialMetric[];
-    pipeline: FinancialMetric[];
-    projections: FinancialProjection[];
-  };
-  expenses: {
-    headline: FinancialMetric[];
-    runway: FinancialRunway;
-    alerts: FinancialAlert[];
-  };
-
     summary: FinancialMetric[];
     pipeline: FinancialMetric[];
     efficiency: FinancialMetric[];
@@ -186,136 +180,26 @@ codex/integrate-revenue-and-expense-tabs-ugnmqm
     spendTrend: ExpenseTrendPoint[];
   };
   predictability: PredictabilityData;
- main
 };
 
 const DEMO_DATA: FinancialsData = {
   source: "demo",
   lastUpdated: new Date().toISOString(),
   revenue: {
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-    headline: [
-      { id: "arr", label: "ARR", amount: 2400000, delta: 12.4, trend: "up", target: 3000000 },
-      { id: "net-retention", label: "Net Revenue Retention", amount: 134, delta: 4.1, trend: "up", target: 140 },
-      { id: "gross-margin", label: "Gross Margin", amount: 78, delta: 1.2, trend: "up", target: 80 },
-    ],
-    pipeline: [
-      { id: "pipeline", label: "Pipeline Coverage", amount: 3.4, delta: -0.3, trend: "down", target: 4 },
-      { id: "avg-deal", label: "Avg Deal Size", amount: 58000, delta: 2.6, trend: "up" },
-      { id: "sales-cycle", label: "Sales Cycle", amount: 34, delta: -1.7, trend: "down" },
-    ],
-    projections: [
-      { quarter: "Q1", forecast: 620000, variance: 4.8 },
-      { quarter: "Q2", forecast: 710000, variance: 3.1 },
-      { quarter: "Q3", forecast: 810000, variance: -1.5 },
-      { quarter: "Q4", forecast: 920000, variance: 0.6 },
-    ],
-  },
-  expenses: {
-    headline: [
-      { id: "burn", label: "Monthly Burn", amount: 480000, delta: -2.3, trend: "down" },
-      { id: "opex", label: "OpEx", amount: 220000, delta: 1.1, trend: "up" },
-      { id: "unit", label: "Unit Economics", amount: 42, delta: 6.2, trend: "up" },
-    ],
-    runway: {
-      burnRate: 480000,
-      runwayMonths: 19,
-      nextMilestone: "Series C readiness in 2 quarters",
-    },
-    alerts: [
-      { id: "vendor-spend", severity: "warning", message: "Martech vendor costs spiked 11% MoM" },
-      { id: "hiring-freeze", severity: "info", message: "Hiring slowdown preserving runway" },
-    ],
-  },
-};
-
-=======
     summary: [
-      {
-        id: "total-arr",
-        label: "Total ARR",
-        amount: 4_200_000,
-        delta: 11.2,
-        trend: "up",
-        target: 5_000_000,
-        format: "currency",
-      },
-      {
-        id: "new-arr",
-        label: "New ARR QTD",
-        amount: 380_000,
-        delta: 6.5,
-        trend: "up",
-        target: 450_000,
-        format: "currency",
-      },
-      {
-        id: "expansion-arr",
-        label: "Expansion ARR",
-        amount: 140_000,
-        delta: 3.1,
-        trend: "up",
-        format: "currency",
-      },
+      { id: "arr", label: "ARR", amount: 2_400_000, delta: 12.4, trend: "up", target: 3_000_000, format: "currency" },
+      { id: "net-retention", label: "Net Revenue Retention", amount: 134, delta: 4.1, trend: "up", target: 140, format: "percent", precision: 0 },
+      { id: "gross-margin", label: "Gross Margin", amount: 78, delta: 1.2, trend: "up", target: 80, format: "percent", precision: 0 },
     ],
     pipeline: [
-      {
-        id: "pipeline-coverage",
-        label: "Pipeline Coverage",
-        amount: 4.2,
-        delta: 0.4,
-        trend: "up",
-        target: 5,
-        format: "ratio",
-        precision: 1,
-        suffix: "x",
-      },
-      {
-        id: "committed-pipeline",
-        label: "Committed Pipeline",
-        amount: 910_000,
-        delta: 5.6,
-        trend: "up",
-        format: "currency",
-      },
-      {
-        id: "avg-contract",
-        label: "Avg Contract Value",
-        amount: 72_000,
-        delta: 4.4,
-        trend: "up",
-        format: "currency",
-      },
+      { id: "pipeline", label: "Pipeline Coverage", amount: 3.4, delta: -0.3, trend: "down", target: 4, format: "ratio", precision: 1, suffix: "x" },
+      { id: "avg-deal", label: "Avg Deal Size", amount: 58_000, delta: 2.6, trend: "up", format: "currency" },
+      { id: "sales-cycle", label: "Sales Cycle", amount: 34, delta: -1.7, trend: "down", format: "duration", precision: 0, suffix: "days" },
     ],
     efficiency: [
-      {
-        id: "win-rate",
-        label: "Win Rate",
-        amount: 31,
-        delta: 1.7,
-        trend: "up",
-        target: 35,
-        format: "percent",
-        precision: 1,
-      },
-      {
-        id: "sales-cycle",
-        label: "Sales Cycle",
-        amount: 32,
-        delta: -2.1,
-        trend: "down",
-        format: "duration",
-        suffix: "days",
-      },
-      {
-        id: "lead-velocity",
-        label: "Lead Velocity",
-        amount: 18,
-        delta: 2.4,
-        trend: "up",
-        format: "percent",
-        precision: 1,
-      },
+      { id: "win-rate", label: "Win Rate", amount: 28, delta: 1.4, trend: "up", format: "percent" },
+      { id: "partner-sourced", label: "Partner Sourced", amount: 32, delta: 2.2, trend: "up", format: "percent" },
+      { id: "upsell", label: "Expansion ARR", amount: 420_000, delta: 6.5, trend: "up", format: "currency" },
     ],
     segments: [
       { id: "enterprise", label: "Enterprise", arr: 2_200_000, change: 8.4 },
@@ -339,68 +223,14 @@ codex/integrate-revenue-and-expense-tabs-ugnmqm
   },
   expenses: {
     summary: [
-      {
-        id: "burn",
-        label: "Monthly Burn",
-        amount: 520_000,
-        delta: -1.8,
-        trend: "down",
-        format: "currency",
-      },
-      {
-        id: "operating",
-        label: "Operating Expenses",
-        amount: 310_000,
-        delta: 0.9,
-        trend: "up",
-        format: "currency",
-      },
-      {
-        id: "cash",
-        label: "Cash on Hand",
-        amount: 9_800_000,
-        delta: 2.3,
-        trend: "up",
-        format: "currency",
-      },
+      { id: "burn", label: "Monthly Burn", amount: 520_000, delta: -1.8, trend: "down", format: "currency" },
+      { id: "operating", label: "Operating Expenses", amount: 310_000, delta: 0.9, trend: "up", format: "currency" },
+      { id: "cash", label: "Cash on Hand", amount: 9_800_000, delta: 2.3, trend: "up", format: "currency" },
     ],
     unitEconomics: [
-      {
-        id: "cost-per-client",
-        label: "Cost per Client",
-        amount: 480,
-        delta: -4.2,
-        trend: "down",
-        format: "currency",
-      },
-      {
-        id: "cac-payback",
-        label: "CAC Payback",
-        amount: 9.4,
-        delta: -0.6,
-        trend: "down",
-        format: "duration",
-        precision: 1,
-        suffix: "months",
-      },
-      {
-        id: "support-cost",
-        label: "Support Cost / Ticket",
-        amount: 18,
-        delta: 1.2,
-        trend: "up",
-        format: "currency",
-      },
-      {
-        id: "ltv-cac",
-        label: "LTV to CAC",
-        amount: 4.2,
-        delta: 0.3,
-        trend: "up",
-        format: "ratio",
-        precision: 1,
-        suffix: "x",
-      },
+      { id: "cost-per-client", label: "Cost per Client", amount: 480, delta: -4.2, trend: "down", format: "currency" },
+      { id: "cac-payback", label: "CAC Payback", amount: 9.4, delta: -0.6, trend: "down", format: "duration", precision: 1, suffix: "months" },
+      { id: "ltv-cac", label: "LTV to CAC", amount: 4.2, delta: 0.3, trend: "up", format: "ratio", precision: 1, suffix: "x" },
     ],
     runway: {
       burnRate: 520_000,
@@ -410,42 +240,14 @@ codex/integrate-revenue-and-expense-tabs-ugnmqm
     },
     alerts: [
       { id: "vendor-spend", severity: "warning", message: "Data enrichment renewal is trending +12% month over month." },
+      { id: "support-alert", severity: "critical", message: "Escalation volume has exceeded the support run rate by 8%." },
       { id: "hiring", severity: "info", message: "Hiring slowdown preserving headcount budget across sales." },
-      { id: "support", severity: "critical", message: "Escalation volume has exceeded the support run rate by 8%." },
     ],
     vendorSpend: [
-      {
-        id: "clearbit",
-        vendor: "Clearbit",
-        category: "Data Enrichment",
-        amount: 18_000,
-        change: 12,
-        status: "Renewal due",
-      },
-      {
-        id: "segment",
-        vendor: "Segment",
-        category: "CDP",
-        amount: 24_000,
-        change: 4,
-        status: "Active",
-      },
-      {
-        id: "marketo",
-        vendor: "Marketo",
-        category: "Automation",
-        amount: 32_000,
-        change: -3,
-        status: "Negotiating",
-      },
-      {
-        id: "zendesk",
-        vendor: "Zendesk",
-        category: "Support",
-        amount: 21_000,
-        change: 6,
-        status: "Active",
-      },
+      { id: "clearbit", vendor: "Clearbit", category: "Data Enrichment", amount: 18_000, change: 12, status: "Renewal due" },
+      { id: "segment", vendor: "Segment", category: "CDP", amount: 24_000, change: 4, status: "Active" },
+      { id: "marketo", vendor: "Marketo", category: "Automation", amount: 32_000, change: -3, status: "Negotiating" },
+      { id: "zendesk", vendor: "Zendesk", category: "Support", amount: 21_000, change: 6, status: "Active" },
     ],
     spendTrend: [
       { month: "2024-04", label: "Apr", marketing: 180_000, headcount: 260_000, tooling: 120_000 },
@@ -522,30 +324,9 @@ codex/integrate-revenue-and-expense-tabs-ugnmqm
       },
     ],
     volumeDrivers: [
-      {
-        id: "events",
-        driver: "Field & events",
-        readiness: "Playbook locked",
-        runRate: 420_000,
-        cost: 320_000,
-        signal: "hot",
-      },
-      {
-        id: "paid",
-        driver: "Paid acquisition",
-        readiness: "Budgets cleared",
-        runRate: 310_000,
-        cost: 260_000,
-        signal: "warm",
-      },
-      {
-        id: "partners",
-        driver: "Partner co-selling",
-        readiness: "Rev-share synced",
-        runRate: 210_000,
-        cost: 140_000,
-        signal: "hot",
-      },
+      { id: "events", driver: "Field & events", readiness: "Playbook locked", runRate: 420_000, cost: 320_000, signal: "hot" },
+      { id: "paid", driver: "Paid acquisition", readiness: "Budgets cleared", runRate: 310_000, cost: 260_000, signal: "warm" },
+      { id: "partners", driver: "Partner co-selling", readiness: "Rev-share synced", runRate: 210_000, cost: 140_000, signal: "hot" },
     ],
     channelMix: [
       { id: "inbound", channel: "Inbound", mix: 38, cac: 420, payback: 7.5, intercept: "Full" },
@@ -554,22 +335,8 @@ codex/integrate-revenue-and-expense-tabs-ugnmqm
       { id: "events", channel: "Events", mix: 14, cac: 540, payback: 8.6, intercept: "Full" },
     ],
     voiceSupport: [
-      {
-        id: "voice-sla",
-        label: "Voice SLA",
-        value: "92% within 45s",
-        target: "90%",
-        status: "on-track",
-        trend: 1.4,
-      },
-      {
-        id: "chat",
-        label: "Chat concurrency",
-        value: "3.1 avg",
-        target: "3.0",
-        status: "on-track",
-        trend: 0.6,
-      },
+      { id: "voice-sla", label: "Voice SLA", value: "92% within 45s", target: "90%", status: "on-track", trend: 1.4 },
+      { id: "chat", label: "Chat concurrency", value: "3.1 avg", target: "3.0", status: "on-track", trend: 0.6 },
       {
         id: "deflection",
         label: "Self-serve deflection",
@@ -582,461 +349,296 @@ codex/integrate-revenue-and-expense-tabs-ugnmqm
   },
 };
 
-const TRENDS: TrendDirection[] = ["up", "down", "flat"];
-const FORMATS: MetricFormat[] = ["currency", "percent", "number", "ratio", "duration"];
-const GUARDRAIL_STATUSES: GuardrailStatus[] = ["stable", "watch", "breach"];
-const SIGNAL_STATES: PredictabilityVolumeDriver["signal"][] = ["hot", "warm", "cool"];
-const SUPPORT_STATUSES: SupportStatus[] = ["on-track", "at-risk", "breach"];
-
-function isTrend(value: unknown): value is TrendDirection {
-  return typeof value === "string" && TRENDS.includes(value as TrendDirection);
+function mapMetric(row: SupabaseMetricRow): FinancialMetric {
+  const amount = Number(row.amount ?? 0);
+  const delta = Number(row.delta ?? 0);
+  const targetValue = row.target ?? row.target_value ?? row.target_amount;
+  const precisionValue = row.precision ?? row.decimals;
+  return {
+    id: row.id,
+    label: row.label,
+    amount,
+    delta,
+    trend: (row.trend as TrendDirection) ?? "flat",
+    target: targetValue === null || targetValue === undefined ? undefined : Number(targetValue),
+    format: (row.format as MetricFormat) ?? "currency",
+    precision: precisionValue === null || precisionValue === undefined ? undefined : Number(precisionValue),
+    suffix: row.suffix ?? undefined,
+  };
 }
 
-function isFormat(value: unknown): value is MetricFormat {
-  return typeof value === "string" && FORMATS.includes(value as MetricFormat);
-}
-
-function isGuardrailStatus(value: unknown): value is GuardrailStatus {
-  return typeof value === "string" && GUARDRAIL_STATUSES.includes(value as GuardrailStatus);
-}
-
-function isSignalState(value: unknown): value is PredictabilityVolumeDriver["signal"] {
-  return typeof value === "string" && SIGNAL_STATES.includes(value as PredictabilityVolumeDriver["signal"]);
-}
-
-function isSupportStatus(value: unknown): value is SupportStatus {
-  return typeof value === "string" && SUPPORT_STATUSES.includes(value as SupportStatus);
-}
-
-function toLabel(month: string | null | undefined) {
+function coerceMonthLabel(month: string): string {
   if (!month) return "";
-  const normalised = month.length === 7 ? `${month}-01` : month;
-  const date = new Date(normalised);
-  if (Number.isNaN(date.getTime())) {
+  const parsed = new Date(month);
+  if (Number.isNaN(parsed.valueOf())) {
     return month;
   }
-  return date.toLocaleString("en-US", { month: "short" });
+  return parsed.toLocaleDateString(undefined, { month: "short" });
 }
 
- main
-async function fetchFinancials(): Promise<FinancialsData> {
-  const client = getSupabaseBrowserClient();
-  if (!client) {
-    return DEMO_DATA;
+function collectSupabaseErrors(results: Array<{ error: PostgrestError | null } | undefined>) {
+  return results
+    .map((result) => result?.error)
+    .filter((error): error is PostgrestError => Boolean(error));
+}
+
+async function loadFinancialsFromSupabase(client: SupabaseClient): Promise<FinancialsData | null> {
+  const [
+    revenueMetrics,
+    expenseMetrics,
+    projections,
+    segments,
+    revenueTrend,
+    vendorSpend,
+    expenseTrend,
+    safeLaunch,
+    modeling,
+    guardrails,
+    scenarios,
+    volumeDrivers,
+    channelMix,
+    supportMetrics,
+  ] = await Promise.all([
+    client.from("financial_revenue_metrics").select("*", { head: false }).eq("active", true),
+    client.from("financial_expense_metrics").select("*", { head: false }).eq("active", true),
+    client.from("financial_revenue_projections").select("quarter, forecast, variance").order("quarter"),
+    client.from("financial_revenue_segments").select("id, label, arr, change"),
+    client.from("financial_revenue_mrr_trends").select("month, recurring, services").order("month"),
+    client.from("financial_vendor_spend").select("id, vendor, category, amount, change, status"),
+    client.from("financial_expense_trends").select("month, marketing, headcount, tooling").order("month"),
+    client.from("predictability_safe_launch").select("*").maybeSingle(),
+    client.from("predictability_modeling").select("*").maybeSingle(),
+    client.from("predictability_guardrails").select("id, label, status, detail").order("display_order"),
+    client.from("predictability_scenarios").select("id, scenario, lead_volume, conversion, readiness, go_live").order("display_order"),
+    client.from("predictability_volume_drivers").select("id, driver, readiness, run_rate, cost, signal").order("display_order"),
+    client.from("predictability_channel_mix").select("id, channel, mix, cac, payback, intercept").order("display_order"),
+    client.from("predictability_support_metrics").select("id, label, value, target, status, trend").order("display_order"),
+  ]);
+
+  const errors = collectSupabaseErrors([
+    revenueMetrics,
+    expenseMetrics,
+    projections,
+    segments,
+    revenueTrend,
+    vendorSpend,
+    expenseTrend,
+    safeLaunch,
+    modeling,
+    guardrails,
+    scenarios,
+    volumeDrivers,
+    channelMix,
+    supportMetrics,
+  ]);
+
+  if (errors.length) {
+    errors.forEach((error) => {
+      console.warn("Falling back to demo financial data due to Supabase error", error);
+    });
+    return null;
   }
 
-  try {
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-    const [{ data: revenueData, error: revenueError }, { data: expenseData, error: expenseError }] = await Promise.all([
-      client
-        .from("financial_revenue_metrics")
-        .select("id,label,amount,delta,trend,target,category")
-        .eq("active", true),
-      client
-        .from("financial_expense_metrics")
-        .select("id,label,amount,delta,trend,category,runway_burn,runway_months,next_milestone,severity,message")
-        .eq("active", true),
-    ]);
+  const revenueSummary: FinancialMetric[] = [];
+  const revenuePipeline: FinancialMetric[] = [];
+  const revenueEfficiency: FinancialMetric[] = [];
 
-    if (revenueError || expenseError) {
-      throw revenueError ?? expenseError;
+  (revenueMetrics.data ?? []).forEach((row) => {
+    const metric = mapMetric(row);
+    const section = String(row.section ?? row.category ?? "summary");
+    if (section === "pipeline") {
+      revenuePipeline.push(metric);
+    } else if (section === "efficiency" || section === "unit") {
+      revenueEfficiency.push(metric);
+    } else {
+      revenueSummary.push(metric);
     }
+  });
 
-    const revenueHeadline: FinancialMetric[] = [];
-    const revenuePipeline: FinancialMetric[] = [];
+  const expenseSummary: FinancialMetric[] = [];
+  const unitEconomics: FinancialMetric[] = [];
+  const alerts: FinancialAlert[] = [];
+  let runway: FinancialRunway = {
+    burnRate: DEMO_DATA.expenses.runway.burnRate,
+    runwayMonths: DEMO_DATA.expenses.runway.runwayMonths,
+    cashBalance: DEMO_DATA.expenses.runway.cashBalance,
+    nextMilestone: DEMO_DATA.expenses.runway.nextMilestone,
+  };
 
-    revenueData?.forEach((row) => {
-      const metric: FinancialMetric = {
-        id: row.id,
-        label: row.label,
-        amount: row.amount ?? 0,
-        delta: row.delta ?? 0,
-        trend: (row.trend as TrendDirection) ?? "flat",
-        target: row.target ?? undefined,
+  (expenseMetrics.data ?? []).forEach((row) => {
+    const section = String(row.section ?? row.category ?? "summary");
+    const metric = mapMetric(row);
+
+    if (section === "summary") {
+      expenseSummary.push(metric);
+    } else if (section === "unit") {
+      unitEconomics.push(metric);
+    } else if (section === "runway") {
+      runway = {
+        burnRate: Number(row.runway_burn ?? metric.amount ?? 0),
+        runwayMonths: Number(row.runway_months ?? 0),
+        cashBalance: metric.amount ?? 0,
+        nextMilestone: row.next_milestone ?? DEMO_DATA.expenses.runway.nextMilestone,
       };
-      if (row.category === "headline") {
-        revenueHeadline.push(metric);
-      } else {
-        revenuePipeline.push(metric);
-      }
-    });
-
-    let runway: FinancialRunway | null = null;
-    const alerts: FinancialAlert[] = [];
-    const expenseHeadline: FinancialMetric[] = [];
-
-    expenseData?.forEach((row) => {
-      if (row.category === "headline") {
-        expenseHeadline.push({
-          id: row.id,
-          label: row.label,
-          amount: row.amount ?? 0,
-          delta: row.delta ?? 0,
-          trend: (row.trend as TrendDirection) ?? "flat",
-        });
-      }
-      if (row.category === "alert") {
-    const [
-      { data: revenueMetrics, error: revenueError },
-      { data: expenseMetrics, error: expenseError },
-      { data: projectionData, error: projectionError },
-      { data: segmentData, error: segmentError },
-      { data: mrrTrendData, error: mrrError },
-      { data: vendorData, error: vendorError },
-      { data: expenseTrendData, error: expenseTrendError },
-      { data: safeLaunchData, error: safeLaunchError },
-      { data: modelingData, error: modelingError },
-      { data: guardrailData, error: guardrailError },
-      { data: scenarioData, error: scenarioError },
-      { data: driverData, error: driverError },
-      { data: channelMixData, error: channelMixError },
-      { data: supportData, error: supportError },
-    ] = await Promise.all([
-      client
-        .from("financial_revenue_metrics")
-        .select("id,label,amount,delta,trend,target,category,format,precision,suffix,section")
-        .eq("active", true),
-      client
-        .from("financial_expense_metrics")
-        .select(
-          "id,label,amount,delta,trend,category,runway_burn,runway_months,next_milestone,severity,message,format,precision,suffix,section"
-        )
-        .eq("active", true),
-      client
-        .from("financial_revenue_projections")
-        .select("quarter,forecast,variance")
-        .order("quarter", { ascending: true }),
-      client
-        .from("financial_revenue_segments")
-        .select("id,label,arr,change")
-        .order("arr", { ascending: false }),
-      client
-        .from("financial_revenue_mrr_trends")
-        .select("month,recurring,services")
-        .order("month", { ascending: true }),
-      client
-        .from("financial_vendor_spend")
-        .select("id,vendor,category,amount,change,status")
-        .order("amount", { ascending: false }),
-      client
-        .from("financial_expense_trends")
-        .select("month,marketing,headcount,tooling")
-        .order("month", { ascending: true }),
-      client
-        .from("predictability_safe_launch")
-        .select(
-          "qualified_leads,qualified_lead_low,qualified_lead_high,activation_window_days,cost_to_scale,budget_guardrail,intercept_coverage,twilio_verified,automation_confidence"
-        )
-        .maybeSingle(),
-      client
-        .from("predictability_modeling")
-        .select("forecast_accuracy,reliability_score,intercept_margin,scenario_confidence,notes")
-        .maybeSingle(),
-      client
-        .from("predictability_guardrails")
-        .select("id,label,status,detail")
-        .order("display_order", { ascending: true }),
-      client
-        .from("predictability_scenarios")
-        .select("id,scenario,lead_volume,conversion,readiness,go_live")
-        .order("display_order", { ascending: true }),
-      client
-        .from("predictability_volume_drivers")
-        .select("id,driver,readiness,run_rate,cost,signal")
-        .order("display_order", { ascending: true }),
-      client
-        .from("predictability_channel_mix")
-        .select("id,channel,mix,cac,payback,intercept")
-        .order("mix", { ascending: false }),
-      client
-        .from("predictability_support_metrics")
-        .select("id,label,value,target,status,trend")
-        .order("display_order", { ascending: true }),
-    ]);
-
-    const queryError =
-      revenueError ||
-      expenseError ||
-      projectionError ||
-      segmentError ||
-      mrrError ||
-      vendorError ||
-      expenseTrendError ||
-      safeLaunchError ||
-      modelingError ||
-      guardrailError ||
-      scenarioError ||
-      driverError ||
-      channelMixError ||
-      supportError;
-    if (queryError) {
-      throw queryError;
+    } else if (section === "alert" && row.message) {
+      alerts.push({
+        id: row.id,
+        severity: (row.severity as FinancialAlert["severity"]) ?? "info",
+        message: row.message,
+      });
     }
+  });
 
-    const summaryMetrics: FinancialMetric[] = [];
-    const pipelineMetrics: FinancialMetric[] = [];
-    const efficiencyMetrics: FinancialMetric[] = [];
+  const projectionsData: FinancialProjection[] = (projections.data ?? []).map((row) => ({
+    quarter: row.quarter,
+    forecast: Number(row.forecast ?? 0),
+    variance: Number(row.variance ?? 0),
+  }));
 
-    revenueMetrics?.forEach((row) => {
-      const metric: FinancialMetric = {
-        id: row.id,
-        label: row.label,
-        amount: Number(row.amount ?? 0),
-        delta: Number(row.delta ?? 0),
-        trend: isTrend(row.trend) ? row.trend : "flat",
-        target: row.target ?? undefined,
-        format: isFormat(row.format) ? row.format : "currency",
-        precision: typeof row.precision === "number" ? row.precision : undefined,
-        suffix: row.suffix ?? undefined,
-      };
+  const segmentsData: RevenueSegment[] = (segments.data ?? []).map((row) => ({
+    id: row.id,
+    label: row.label,
+    arr: Number(row.arr ?? 0),
+    change: Number(row.change ?? 0),
+  }));
 
-      const bucket = row.section ?? row.category;
-      if (bucket === "pipeline") {
-        pipelineMetrics.push(metric);
-      } else if (bucket === "efficiency") {
-        efficiencyMetrics.push(metric);
-      } else {
-        summaryMetrics.push(metric);
-      }
-    });
+  const revenueTrendData: RevenueTrendPoint[] = (revenueTrend.data ?? []).map((row) => ({
+    month: row.month,
+    label: coerceMonthLabel(row.month),
+    recurring: Number(row.recurring ?? 0),
+    services: Number(row.services ?? 0),
+  }));
 
-    const summaryExpenses: FinancialMetric[] = [];
-    const unitEconomics: FinancialMetric[] = [];
-    const alerts: FinancialAlert[] = [];
-    let runway: FinancialRunway | null = null;
+  const vendorSpendData: VendorSpend[] = (vendorSpend.data ?? []).map((row) => ({
+    id: row.id,
+    vendor: row.vendor,
+    category: row.category,
+    amount: Number(row.amount ?? 0),
+    change: Number(row.change ?? 0),
+    status: row.status,
+  }));
 
-    expenseMetrics?.forEach((row) => {
-      const bucket = row.section ?? row.category;
+  const expenseTrendData: ExpenseTrendPoint[] = (expenseTrend.data ?? []).map((row) => ({
+    month: row.month,
+    label: coerceMonthLabel(row.month),
+    marketing: Number(row.marketing ?? 0),
+    headcount: Number(row.headcount ?? 0),
+    tooling: Number(row.tooling ?? 0),
+  }));
 
-      if (bucket === "alert" || row.category === "alert") {
- main
-        alerts.push({
-          id: row.id,
-          severity: (row.severity as FinancialAlert["severity"]) ?? "info",
-          message: row.message ?? "",
-        });
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-      }
-      if (row.category === "runway" && !runway) {
-        runway = {
-          burnRate: row.runway_burn ?? 0,
-          runwayMonths: row.runway_months ?? 0,
-          nextMilestone: row.next_milestone ?? "",
-        };
-      }
-    });
+  const safeLaunchRow = safeLaunch.data;
+  const modelingRow = modeling.data;
 
-    const { data: projectionData, error: projectionError } = await client
-      .from("financial_revenue_projections")
-      .select("quarter,forecast,variance")
-      .order("quarter", { ascending: true });
-
-    if (projectionError) {
-      throw projectionError;
-    }
-        return;
-      }
-
-      if (bucket === "runway") {
-        runway = {
-          burnRate: Number(row.runway_burn ?? row.amount ?? 0),
-          runwayMonths: Number(row.runway_months ?? 0),
-          cashBalance: Number(row.amount ?? DEMO_DATA.expenses.runway.cashBalance),
-          nextMilestone: row.next_milestone ?? "",
-        };
-        return;
-      }
-
-      const metric: FinancialMetric = {
-        id: row.id,
-        label: row.label,
-        amount: Number(row.amount ?? 0),
-        delta: Number(row.delta ?? 0),
-        trend: isTrend(row.trend) ? row.trend : "flat",
-        format: isFormat(row.format) ? row.format : "currency",
-        precision: typeof row.precision === "number" ? row.precision : undefined,
-        suffix: row.suffix ?? undefined,
-      };
-
-      if (bucket === "unit") {
-        unitEconomics.push(metric);
-      } else {
-        summaryExpenses.push(metric);
-      }
-    });
-
-    const projections: FinancialProjection[] = projectionData?.map((row) => ({
-      quarter: row.quarter,
-      forecast: Number(row.forecast ?? 0),
-      variance: Number(row.variance ?? 0),
-    })) ?? [];
-
-    const segments: RevenueSegment[] = segmentData?.map((row) => ({
+  const predictability: PredictabilityData = {
+    safeLaunch: safeLaunchRow
+      ? {
+          qualifiedLeads: Number(safeLaunchRow.qualified_leads ?? 0),
+          qualifiedLeadLow: Number(safeLaunchRow.qualified_lead_low ?? 0),
+          qualifiedLeadHigh: Number(safeLaunchRow.qualified_lead_high ?? 0),
+          activationWindowDays: Number(safeLaunchRow.activation_window_days ?? 0),
+          costToScale: Number(safeLaunchRow.cost_to_scale ?? 0),
+          budgetGuardrail: Number(safeLaunchRow.budget_guardrail ?? 0),
+          interceptCoverage: Number(safeLaunchRow.intercept_coverage ?? 0),
+          twilioVerified: Number(safeLaunchRow.twilio_verified ?? 0),
+          automationConfidence: Number(safeLaunchRow.automation_confidence ?? 0),
+        }
+      : DEMO_DATA.predictability.safeLaunch,
+    modeling: modelingRow
+      ? {
+          forecastAccuracy: Number(modelingRow.forecast_accuracy ?? 0),
+          reliabilityScore: Number(modelingRow.reliability_score ?? 0),
+          interceptMargin: Number(modelingRow.intercept_margin ?? 0),
+          scenarioConfidence: Number(modelingRow.scenario_confidence ?? 0),
+          notes: modelingRow.notes ?? "",
+        }
+      : DEMO_DATA.predictability.modeling,
+    guardrails: (guardrails.data ?? []).map((row) => ({
       id: row.id,
       label: row.label,
-      arr: Number(row.arr ?? 0),
-      change: Number(row.change ?? 0),
-    })) ?? [];
-
-    const mrrTrend: RevenueTrendPoint[] = mrrTrendData?.map((row) => ({
-      month: row.month,
-      label: toLabel(row.month),
-      recurring: Number(row.recurring ?? 0),
-      services: Number(row.services ?? 0),
-    })) ?? [];
-
-    const vendorSpend: VendorSpend[] = vendorData?.map((row) => ({
-      id: row.id,
-      vendor: row.vendor,
-      category: row.category,
-      amount: Number(row.amount ?? 0),
-      change: Number(row.change ?? 0),
-      status: row.status,
-    })) ?? [];
-
-    const spendTrend: ExpenseTrendPoint[] = expenseTrendData?.map((row) => ({
-      month: row.month,
-      label: toLabel(row.month),
-      marketing: Number(row.marketing ?? 0),
-      headcount: Number(row.headcount ?? 0),
-      tooling: Number(row.tooling ?? 0),
-    })) ?? [];
-
-    const safeLaunch = safeLaunchData
-      ? {
-          qualifiedLeads: Number(safeLaunchData.qualified_leads ?? DEMO_DATA.predictability.safeLaunch.qualifiedLeads),
-          qualifiedLeadLow: Number(safeLaunchData.qualified_lead_low ?? DEMO_DATA.predictability.safeLaunch.qualifiedLeadLow),
-          qualifiedLeadHigh: Number(safeLaunchData.qualified_lead_high ?? DEMO_DATA.predictability.safeLaunch.qualifiedLeadHigh),
-          activationWindowDays: Number(
-            safeLaunchData.activation_window_days ?? DEMO_DATA.predictability.safeLaunch.activationWindowDays
-          ),
-          costToScale: Number(safeLaunchData.cost_to_scale ?? DEMO_DATA.predictability.safeLaunch.costToScale),
-          budgetGuardrail: Number(safeLaunchData.budget_guardrail ?? DEMO_DATA.predictability.safeLaunch.budgetGuardrail),
-          interceptCoverage: Number(
-            safeLaunchData.intercept_coverage ?? DEMO_DATA.predictability.safeLaunch.interceptCoverage
-          ),
-          twilioVerified: Number(safeLaunchData.twilio_verified ?? DEMO_DATA.predictability.safeLaunch.twilioVerified),
-          automationConfidence: Number(
-            safeLaunchData.automation_confidence ?? DEMO_DATA.predictability.safeLaunch.automationConfidence
-          ),
-        }
-      : DEMO_DATA.predictability.safeLaunch;
-
-    const modeling = modelingData
-      ? {
-          forecastAccuracy: Number(modelingData.forecast_accuracy ?? DEMO_DATA.predictability.modeling.forecastAccuracy),
-          reliabilityScore: Number(modelingData.reliability_score ?? DEMO_DATA.predictability.modeling.reliabilityScore),
-          interceptMargin: Number(modelingData.intercept_margin ?? DEMO_DATA.predictability.modeling.interceptMargin),
-          scenarioConfidence: Number(
-            modelingData.scenario_confidence ?? DEMO_DATA.predictability.modeling.scenarioConfidence
-          ),
-          notes: modelingData.notes ?? DEMO_DATA.predictability.modeling.notes,
-        }
-      : DEMO_DATA.predictability.modeling;
-
-    const guardrails: PredictabilityGuardrail[] = guardrailData?.map((row) => ({
-      id: row.id,
-      label: row.label,
-      status: isGuardrailStatus(row.status) ? row.status : DEMO_DATA.predictability.guardrails[0].status,
+      status: row.status as GuardrailStatus,
       detail: row.detail,
-    })) ?? [];
-
-    const scenarios: PredictabilityScenario[] = scenarioData?.map((row) => ({
+    })),
+    scenarios: (scenarios.data ?? []).map((row) => ({
       id: row.id,
       scenario: row.scenario,
       leadVolume: Number(row.lead_volume ?? 0),
       conversion: Number(row.conversion ?? 0),
       readiness: row.readiness,
       goLive: row.go_live,
-    })) ?? [];
-
-    const volumeDrivers: PredictabilityVolumeDriver[] = driverData?.map((row) => ({
+    })),
+    volumeDrivers: (volumeDrivers.data ?? []).map((row) => ({
       id: row.id,
       driver: row.driver,
       readiness: row.readiness,
       runRate: Number(row.run_rate ?? 0),
       cost: Number(row.cost ?? 0),
-      signal: isSignalState(row.signal) ? row.signal : "warm",
-    })) ?? [];
-
-    const channelMix: PredictabilityChannelMix[] = channelMixData?.map((row) => ({
+      signal: row.signal as PredictabilityVolumeDriver["signal"],
+    })),
+    channelMix: (channelMix.data ?? []).map((row) => ({
       id: row.id,
       channel: row.channel,
       mix: Number(row.mix ?? 0),
       cac: Number(row.cac ?? 0),
       payback: Number(row.payback ?? 0),
       intercept: row.intercept,
-    })) ?? [];
-
-    const voiceSupport: PredictabilitySupportMetric[] = supportData?.map((row) => ({
+    })),
+    voiceSupport: (supportMetrics.data ?? []).map((row) => ({
       id: row.id,
       label: row.label,
       value: row.value,
       target: row.target,
-      status: isSupportStatus(row.status) ? row.status : "on-track",
+      status: row.status as SupportStatus,
       trend: Number(row.trend ?? 0),
-    })) ?? [];
- main
+    })),
+  };
 
-    return {
-      source: "supabase",
-      lastUpdated: new Date().toISOString(),
-      revenue: {
-codex/integrate-revenue-and-expense-tabs-ugnmqm
-        headline: revenueHeadline.length ? revenueHeadline : DEMO_DATA.revenue.headline,
-        pipeline: revenuePipeline.length ? revenuePipeline : DEMO_DATA.revenue.pipeline,
-        projections: projectionData?.length
-          ? projectionData.map((row) => ({
-              quarter: row.quarter,
-              forecast: row.forecast,
-              variance: row.variance,
-            }))
-          : DEMO_DATA.revenue.projections,
-      },
-      expenses: {
-        headline: expenseHeadline.length ? expenseHeadline : DEMO_DATA.expenses.headline,
-        runway: runway ?? DEMO_DATA.expenses.runway,
-        alerts: alerts.length ? alerts : DEMO_DATA.expenses.alerts,
-        summary: summaryMetrics.length ? summaryMetrics : DEMO_DATA.revenue.summary,
-        pipeline: pipelineMetrics.length ? pipelineMetrics : DEMO_DATA.revenue.pipeline,
-        efficiency: efficiencyMetrics.length ? efficiencyMetrics : DEMO_DATA.revenue.efficiency,
-        segments: segments.length ? segments : DEMO_DATA.revenue.segments,
-        projections: projections.length ? projections : DEMO_DATA.revenue.projections,
-        mrrTrend: mrrTrend.length ? mrrTrend : DEMO_DATA.revenue.mrrTrend,
-      },
-      expenses: {
-        summary: summaryExpenses.length ? summaryExpenses : DEMO_DATA.expenses.summary,
-        unitEconomics: unitEconomics.length ? unitEconomics : DEMO_DATA.expenses.unitEconomics,
-        runway: runway ?? DEMO_DATA.expenses.runway,
-        alerts: alerts.length ? alerts : DEMO_DATA.expenses.alerts,
-        vendorSpend: vendorSpend.length ? vendorSpend : DEMO_DATA.expenses.vendorSpend,
-        spendTrend: spendTrend.length ? spendTrend : DEMO_DATA.expenses.spendTrend,
-      },
-      predictability: {
-        safeLaunch,
-        modeling,
-        guardrails: guardrails.length ? guardrails : DEMO_DATA.predictability.guardrails,
-        scenarios: scenarios.length ? scenarios : DEMO_DATA.predictability.scenarios,
-        volumeDrivers: volumeDrivers.length ? volumeDrivers : DEMO_DATA.predictability.volumeDrivers,
-        channelMix: channelMix.length ? channelMix : DEMO_DATA.predictability.channelMix,
-        voiceSupport: voiceSupport.length ? voiceSupport : DEMO_DATA.predictability.voiceSupport,
- main
-      },
-    };
+  return {
+    source: "supabase",
+    lastUpdated: new Date().toISOString(),
+    revenue: {
+      summary: revenueSummary.length ? revenueSummary : DEMO_DATA.revenue.summary,
+      pipeline: revenuePipeline.length ? revenuePipeline : DEMO_DATA.revenue.pipeline,
+      efficiency: revenueEfficiency.length ? revenueEfficiency : DEMO_DATA.revenue.efficiency,
+      segments: segmentsData.length ? segmentsData : DEMO_DATA.revenue.segments,
+      projections: projectionsData.length ? projectionsData : DEMO_DATA.revenue.projections,
+      mrrTrend: revenueTrendData.length ? revenueTrendData : DEMO_DATA.revenue.mrrTrend,
+    },
+    expenses: {
+      summary: expenseSummary.length ? expenseSummary : DEMO_DATA.expenses.summary,
+      unitEconomics: unitEconomics.length ? unitEconomics : DEMO_DATA.expenses.unitEconomics,
+      runway,
+      alerts: alerts.length ? alerts : DEMO_DATA.expenses.alerts,
+      vendorSpend: vendorSpendData.length ? vendorSpendData : DEMO_DATA.expenses.vendorSpend,
+      spendTrend: expenseTrendData.length ? expenseTrendData : DEMO_DATA.expenses.spendTrend,
+    },
+    predictability,
+  };
+}
+
+async function fetchFinancials(): Promise<FinancialsData> {
+  const supabase = getSupabaseBrowserClient();
+  if (!supabase) {
+    return { ...DEMO_DATA, lastUpdated: new Date().toISOString() };
+  }
+
+  try {
+    const result = await loadFinancialsFromSupabase(supabase as SupabaseClient);
+    if (!result) {
+      return { ...DEMO_DATA, lastUpdated: new Date().toISOString() };
+    }
+    return result;
   } catch (error) {
-    console.warn("Falling back to demo financial data", error);
-    return {
-      ...DEMO_DATA,
-      lastUpdated: new Date().toISOString(),
-    };
+    console.error("Failed to load financials from Supabase", error);
+    return { ...DEMO_DATA, lastUpdated: new Date().toISOString() };
   }
 }
 
 export function useFinancialsData() {
-  return useQuery({
-    queryKey: ["financials", "dashboard"],
+  return useQuery<FinancialsData>({
+    queryKey: ["financials"],
     queryFn: fetchFinancials,
     staleTime: 60_000,
-    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
   });
 }
+export { DEMO_DATA as FALLBACK_FINANCIALS };

--- a/src/hooks/useLeadIngestion.ts
+++ b/src/hooks/useLeadIngestion.ts
@@ -1,0 +1,416 @@
+import { useCallback, useState } from "react"
+import Papa from "papaparse"
+import * as XLSX from "xlsx"
+
+import { toast } from "@/components/ui/sonner"
+import { getSupabaseBrowserClient } from "@/lib/supabaseClient"
+
+const CHUNK_SIZE = 500
+const MAX_SAFE_TEXT_LOAD_BYTES = 15 * 1024 * 1024 // 15 MB guardrail for pre-counting rows
+
+export type UploadStage = "idle" | "preparing" | "uploading" | "success" | "error"
+
+interface UploadState {
+  stage: UploadStage
+  fileName: string | null
+  ingestionId: string | null
+  processedRows: number
+  totalRows: number | null
+  errorMessage: string | null
+}
+
+interface LeadInsertPayload {
+  ingestion_id: string
+  source_filename: string
+  first_name: string | null
+  last_name: string | null
+  email: string | null
+  phone: string | null
+  company: string | null
+  hashed_phone: string | null
+  raw_payload: Record<string, unknown>
+}
+
+const FIRST_NAME_KEYS = ["first_name", "firstname", "first", "givenname"]
+const LAST_NAME_KEYS = ["last_name", "lastname", "last", "surname", "familyname"]
+const EMAIL_KEYS = ["email", "email_address", "emailaddress", "primaryemail"]
+const PHONE_KEYS = ["phone", "phone_number", "phonenumber", "mobile", "mobilephone", "contactnumber", "cell"]
+const COMPANY_KEYS = ["company", "company_name", "organization", "organisation", "org", "brand", "employer"]
+
+const NORMALIZE_KEY_REGEX = /[^a-z0-9]/g
+
+const INITIAL_STATE: UploadState = {
+  stage: "idle",
+  fileName: null,
+  ingestionId: null,
+  processedRows: 0,
+  totalRows: null,
+  errorMessage: null,
+}
+
+function normalizeKey(key: string) {
+  return key.toLowerCase().replace(NORMALIZE_KEY_REGEX, "")
+}
+
+function sanitizeRow(row: Record<string, unknown>): Record<string, unknown> {
+  return Object.entries(row).reduce<Record<string, unknown>>((acc, [key, value]) => {
+    const trimmedKey = key.trim()
+
+    if (typeof value === "string") {
+      const cleaned = value.replace(/\uFEFF/g, "").trim()
+      acc[trimmedKey] = cleaned.length > 0 ? cleaned : null
+      return acc
+    }
+
+    if (typeof value === "number") {
+      acc[trimmedKey] = Number.isFinite(value) ? value : null
+      return acc
+    }
+
+    if (value instanceof Date) {
+      acc[trimmedKey] = value.toISOString()
+      return acc
+    }
+
+    acc[trimmedKey] = value ?? null
+    return acc
+  }, {})
+}
+
+function isRowEmpty(row: Record<string, unknown>) {
+  return Object.values(row).every((value) => {
+    if (value === null || value === undefined) return true
+    if (typeof value === "string") return value.trim().length === 0
+    return false
+  })
+}
+
+function buildKeyLookup(row: Record<string, unknown>) {
+  return Object.keys(row).reduce<Map<string, string>>((map, key) => {
+    const normalized = normalizeKey(key)
+    if (!map.has(normalized)) {
+      map.set(normalized, key)
+    }
+    return map
+  }, new Map<string, string>())
+}
+
+function extractField(
+  row: Record<string, unknown>,
+  lookup: Map<string, string>,
+  candidates: string[],
+): string | null {
+  for (const candidate of candidates) {
+    const normalizedCandidate = normalizeKey(candidate)
+    const originalKey = lookup.get(normalizedCandidate)
+    if (!originalKey) continue
+
+    const value = row[originalKey]
+    if (value === null || value === undefined) return null
+
+    if (typeof value === "string") {
+      const trimmed = value.trim()
+      return trimmed.length > 0 ? trimmed : null
+    }
+
+    return String(value)
+  }
+
+  return null
+}
+
+async function sha256(value: string) {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(value)
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data)
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+function normalizePhone(value: string | null) {
+  if (!value) return null
+  const digitsOnly = value.replace(/\D/g, "")
+  if (!digitsOnly) return null
+  return digitsOnly
+}
+
+async function transformRows(
+  rows: Record<string, unknown>[],
+  ingestionId: string,
+  fileName: string,
+): Promise<LeadInsertPayload[]> {
+  const transformed: LeadInsertPayload[] = []
+
+  for (const rawRow of rows) {
+    const sanitized = sanitizeRow(rawRow)
+    if (isRowEmpty(sanitized)) continue
+
+    const lookup = buildKeyLookup(sanitized)
+    const firstName = extractField(sanitized, lookup, FIRST_NAME_KEYS)
+    const lastName = extractField(sanitized, lookup, LAST_NAME_KEYS)
+    const email = extractField(sanitized, lookup, EMAIL_KEYS)
+    const phone = normalizePhone(extractField(sanitized, lookup, PHONE_KEYS))
+    const company = extractField(sanitized, lookup, COMPANY_KEYS)
+
+    const hashedPhone = phone ? await sha256(phone.replace(/\D/g, "")) : null
+
+    transformed.push({
+      ingestion_id: ingestionId,
+      source_filename: fileName,
+      first_name: firstName,
+      last_name: lastName,
+      email: email ? email.toLowerCase() : null,
+      phone,
+      company,
+      hashed_phone: hashedPhone,
+      raw_payload: sanitized,
+    })
+  }
+
+  return transformed
+}
+
+async function estimateCsvRowCount(file: File) {
+  if (file.size > MAX_SAFE_TEXT_LOAD_BYTES) {
+    return null
+  }
+
+  const text = await file.text()
+  const lines = text.split(/\r\n|\n|\r/g).filter((line) => line.trim().length > 0)
+  if (lines.length <= 1) {
+    return Math.max(0, lines.length - 1)
+  }
+
+  return lines.length - 1
+}
+
+async function readXlsxRows(file: File) {
+  const buffer = await file.arrayBuffer()
+  const workbook = XLSX.read(buffer, { type: "array" })
+  const sheetName = workbook.SheetNames[0]
+  if (!sheetName) return []
+  const worksheet = workbook.Sheets[sheetName]
+  return XLSX.utils.sheet_to_json<Record<string, unknown>>(worksheet, {
+    defval: null,
+    blankrows: false,
+  })
+}
+
+function chunkArray<T>(items: T[], chunkSize: number) {
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize))
+  }
+  return chunks
+}
+
+export function useLeadIngestion() {
+  const [uploadState, setUploadState] = useState<UploadState>(INITIAL_STATE)
+
+  const reset = useCallback(() => {
+    setUploadState(INITIAL_STATE)
+  }, [])
+
+  const handleFileUpload = useCallback(
+    async (file: File) => {
+      const supabase = getSupabaseBrowserClient()
+
+      if (!supabase) {
+        toast.error("Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable uploads.")
+        setUploadState({
+          ...INITIAL_STATE,
+          stage: "error",
+          errorMessage: "Supabase credentials are missing.",
+          fileName: file.name,
+        })
+        return
+      }
+
+      setUploadState({
+        stage: "preparing",
+        fileName: file.name,
+        ingestionId: null,
+        processedRows: 0,
+        totalRows: null,
+        errorMessage: null,
+      })
+
+      const extension = file.name.split(".").pop()?.toLowerCase()
+      if (!extension || !["csv", "xlsx", "xls"].includes(extension)) {
+        const message = "Unsupported file type. Upload a CSV or XLSX file."
+        toast.error(message)
+        setUploadState({
+          stage: "error",
+          fileName: file.name,
+          ingestionId: null,
+          processedRows: 0,
+          totalRows: null,
+          errorMessage: message,
+        })
+        return
+      }
+
+      let totalRows: number | null = null
+      if (extension === "csv") {
+        totalRows = await estimateCsvRowCount(file)
+      }
+
+      let ingestionId: string | null = null
+      let processedRows = 0
+
+      try {
+        const { data: ingestion, error: ingestionError } = await supabase
+          .from("lead_ingestions")
+          .insert({
+            filename: file.name,
+            status: "processing",
+            total_rows: totalRows,
+            processed_rows: 0,
+          })
+          .select("id")
+          .single()
+
+        if (ingestionError) throw ingestionError
+        const confirmedIngestionId = ingestion.id as string
+        ingestionId = confirmedIngestionId
+
+        setUploadState((prev) => ({
+          ...prev,
+          ingestionId,
+          totalRows,
+          stage: "uploading",
+        }))
+
+        const persistProgress = async (rowsProcessed: number, inferredTotal?: number) => {
+          const updatePayload: Record<string, unknown> = { processed_rows: rowsProcessed }
+          if (typeof inferredTotal === "number" && inferredTotal > 0) {
+            updatePayload.total_rows = inferredTotal
+          }
+          const { error: progressError } = await supabase
+            .from("lead_ingestions")
+            .update(updatePayload)
+            .eq("id", confirmedIngestionId)
+          if (progressError) {
+            console.warn("Failed to persist ingestion progress", progressError)
+          }
+        }
+
+        if (extension === "csv") {
+          await new Promise<void>((resolve, reject) => {
+            Papa.parse<Record<string, unknown>>(file, {
+              header: true,
+              skipEmptyLines: true,
+              worker: true,
+              chunkSize: CHUNK_SIZE,
+              chunk: async (results, parser) => {
+                parser.pause()
+                try {
+                  const transformed = await transformRows(results.data, ingestionId!, file.name)
+                  if (transformed.length > 0) {
+                    const { error: insertError } = await supabase.from("leads").insert(transformed)
+                    if (insertError) throw insertError
+                    processedRows += transformed.length
+                    setUploadState((prev) => ({
+                      ...prev,
+                      processedRows,
+                    }))
+                    await persistProgress(processedRows)
+                  }
+                  parser.resume()
+                } catch (chunkError) {
+                  parser.abort()
+                  reject(chunkError)
+                }
+              },
+              complete: async () => {
+                if (totalRows === null) {
+                  totalRows = processedRows
+                  setUploadState((prev) => ({
+                    ...prev,
+                    totalRows,
+                  }))
+                  await persistProgress(processedRows, totalRows)
+                }
+                resolve()
+              },
+              error: (error) => {
+                reject(error)
+              },
+            })
+          })
+        } else {
+          const rows = await readXlsxRows(file)
+          if (!totalRows) {
+            totalRows = rows.length
+          }
+
+          for (const chunk of chunkArray(rows, CHUNK_SIZE)) {
+            const transformed = await transformRows(chunk, ingestionId, file.name)
+            if (transformed.length === 0) continue
+
+            const { error: insertError } = await supabase.from("leads").insert(transformed)
+            if (insertError) throw insertError
+
+            processedRows += transformed.length
+            setUploadState((prev) => ({
+              ...prev,
+              processedRows,
+              totalRows,
+            }))
+            await persistProgress(processedRows, totalRows)
+          }
+        }
+
+        const completedAt = new Date().toISOString()
+        await supabase
+          .from("lead_ingestions")
+          .update({
+            status: "succeeded",
+            processed_rows: processedRows,
+            total_rows: totalRows ?? processedRows,
+            completed_at: completedAt,
+          })
+          .eq("id", ingestionId)
+
+        setUploadState((prev) => ({
+          ...prev,
+          stage: "success",
+          processedRows,
+          totalRows: totalRows ?? processedRows,
+        }))
+        toast.success(`Ingested ${processedRows.toLocaleString()} lead records from ${file.name}`)
+      } catch (error) {
+        console.error("Lead ingestion failed", error)
+        const errorMessage =
+          error instanceof Error ? error.message : "Lead ingestion failed. Check console for more details."
+
+        if (ingestionId) {
+          await supabase
+            .from("lead_ingestions")
+            .update({
+              status: "failed",
+              error: errorMessage,
+              processed_rows: processedRows,
+            })
+            .eq("id", ingestionId)
+        }
+
+        toast.error(errorMessage)
+        setUploadState((prev) => ({
+          ...prev,
+          stage: "error",
+          errorMessage,
+        }))
+      }
+    },
+    [],
+  )
+
+  return {
+    uploadState,
+    isUploading: uploadState.stage === "preparing" || uploadState.stage === "uploading",
+    handleFileUpload,
+    reset,
+  }
+}

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -1,17 +1,11 @@
- codex/add-skin-selector-for-color-theme
-import type { SupabaseClient } from "@supabase/supabase-js";
-=======
 import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
- main
+
 import { resolveSkinId, type SkinId } from "./skins";
 
 const STORAGE_KEY = "mwcc:dashboard-skin";
 
- codex/add-skin-selector-for-color-theme
-=======
 type StorageCallback = (skinId: SkinId | null) => void;
 
-main
 export function readStoredSkin(): SkinId | null {
   if (typeof window === "undefined") {
     return null;
@@ -42,8 +36,6 @@ export function persistStoredSkin(skinId: SkinId) {
   }
 }
 
-codex/add-skin-selector-for-color-theme
-=======
 export function subscribeToStoredSkin(callback: StorageCallback): () => void {
   if (typeof window === "undefined") {
     return () => {};
@@ -69,19 +61,15 @@ export function subscribeToStoredSkin(callback: StorageCallback): () => void {
   };
 }
 
- main
 function isAuthSessionError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
 
-  return "message" in error && typeof (error as { message?: unknown }).message === "string"
-    ? (error as { message: string }).message.toLowerCase().includes("session")
-    : false;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" && message.toLowerCase().includes("session");
 }
 
-codex/add-skin-selector-for-color-theme
-=======
 function getPostgrestCode(error: unknown): string | null {
   if (error && typeof error === "object" && "code" in error) {
     const code = (error as PostgrestError).code;
@@ -94,7 +82,6 @@ function getPostgrestCode(error: unknown): string | null {
 
 function isIgnorablePreferenceError(error: unknown): boolean {
   const code = getPostgrestCode(error);
-
   if (!code) {
     return false;
   }
@@ -104,7 +91,6 @@ function isIgnorablePreferenceError(error: unknown): boolean {
   return ["42P01", "42501", "PGRST116", "PGRST301"].includes(code);
 }
 
-main
 function formatSupabaseError(error: unknown, fallback: string): Error {
   if (error instanceof Error) {
     return error;
@@ -112,9 +98,7 @@ function formatSupabaseError(error: unknown, fallback: string): Error {
   return new Error(fallback);
 }
 
-export async function fetchRemoteSkin(
-  client: SupabaseClient,
-): Promise<SkinId | null> {
+export async function fetchRemoteSkin(client: SupabaseClient): Promise<SkinId | null> {
   const {
     data: { user },
     error: authError,
@@ -138,12 +122,11 @@ export async function fetchRemoteSkin(
     .maybeSingle();
 
   if (error) {
-codex/add-skin-selector-for-color-theme
-    if ("code" in error && (error as { code?: string }).code === "PGRST116") {
-=======
     if (isIgnorablePreferenceError(error)) {
-      console.warn("Dashboard skin preference table unavailable, falling back to defaults", error);
-main
+      console.warn(
+        "Dashboard skin preference table unavailable, falling back to defaults",
+        error,
+      );
       return null;
     }
 
@@ -186,14 +169,14 @@ export async function persistRemoteSkin(client: SupabaseClient, skinId: SkinId):
     );
 
   if (error) {
-codex/add-skin-selector-for-color-theme
-=======
     if (isIgnorablePreferenceError(error)) {
-      console.warn("Unable to persist dashboard skin preference remotely; continuing with local value", error);
+      console.warn(
+        "Unable to persist dashboard skin preference remotely; continuing with local value",
+        error,
+      );
       return;
     }
 
- main
     throw formatSupabaseError(error, "Failed to persist dashboard skin preference");
   }
 }

--- a/src/lib/skins.ts
+++ b/src/lib/skins.ts
@@ -8,8 +8,6 @@ export type SkinDefinition = {
   headline: string;
 };
 
-codex/add-skin-selector-for-color-theme
- codex/add-skin-selector-for-color-theme-on40yv
 const liquidGlassTokens: Record<string, string> = {
   background: "210 40% 98%",
   foreground: "215 32% 14%",
@@ -57,8 +55,6 @@ const liquidGlassTokens: Record<string, string> = {
   "warning-amber": "44 90% 58%",
 };
 
-main
-main
 const fortune100Tokens: Record<string, string> = {
   background: "218 23% 4%",
   foreground: "210 40% 95%",
@@ -88,16 +84,10 @@ const fortune100Tokens: Record<string, string> = {
   "sidebar-accent-foreground": "210 40% 95%",
   "sidebar-border": "218 23% 10%",
   "sidebar-ring": "212 100% 45%",
-codex/add-skin-selector-for-color-theme
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-	
   "glass-base": "218 28% 10%",
   "glass-highlight": "210 40% 88%",
   "glass-border": "218 24% 18%",
   "glass-shadow": "212 90% 32%",
-main
- main
   "corporate-blue": "212 100% 45%",
   "corporate-navy": "218 50% 20%",
   "corporate-silver": "210 15% 75%",
@@ -141,16 +131,10 @@ const auroraGlassTokens: Record<string, string> = {
   "sidebar-accent-foreground": "198 48% 92%",
   "sidebar-border": "225 36% 26%",
   "sidebar-ring": "195 86% 62%",
- codex/add-skin-selector-for-color-theme
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-
   "glass-base": "223 52% 16%",
   "glass-highlight": "197 56% 94%",
   "glass-border": "223 40% 28%",
   "glass-shadow": "195 70% 48%",
-main
- main
   "corporate-blue": "195 86% 62%",
   "corporate-navy": "224 60% 18%",
   "corporate-silver": "197 28% 74%",
@@ -194,16 +178,10 @@ const emberVanguardTokens: Record<string, string> = {
   "sidebar-accent-foreground": "28 36% 94%",
   "sidebar-border": "28 32% 26%",
   "sidebar-ring": "16 92% 58%",
-codex/add-skin-selector-for-color-theme
-=======
-codex/add-skin-selector-for-color-theme-on40yv
-
   "glass-base": "24 38% 12%",
   "glass-highlight": "32 40% 92%",
   "glass-border": "26 34% 24%",
   "glass-shadow": "16 88% 42%",
-main
- main
   "corporate-blue": "205 82% 54%",
   "corporate-navy": "220 50% 20%",
   "corporate-silver": "35 24% 70%",
@@ -220,34 +198,21 @@ main
 
 const SKIN_DEFINITIONS = [
   {
-codex/add-skin-selector-for-color-theme
-=======
- codex/add-skin-selector-for-color-theme-on40yv
- id: "liquid-glass-pro",
+    id: "liquid-glass-pro",
     name: "Liquid Glass PRO",
     description: "Crisp white glass with executive neon accents.",
     cssVars: liquidGlassTokens,
-    previewColors: [
-      "hsl(213 90% 56%)",
-      "hsl(152 76% 45%)",
-      "hsl(0 72% 56%)",
-    ],
+    previewColors: ["hsl(213 90% 56%)", "hsl(152 76% 45%)", "hsl(0 72% 56%)"],
     heroGradient:
       "linear-gradient(135deg, hsla(213,90%,56%,0.18) 0%, hsla(152,76%,45%,0.12) 45%, hsla(0,0%,100%,0.8) 100%)",
     headline: "Liquid glass control",
   },
   {
- main
- main
     id: "fortune-100",
     name: "Fortune 100 Steel",
     description: "Executive navy glass with electric revenue pulses.",
     cssVars: fortune100Tokens,
-    previewColors: [
-      "hsl(212 100% 45%)",
-      "hsl(210 10% 85%)",
-      "hsl(355 85% 55%)",
-    ],
+    previewColors: ["hsl(212 100% 45%)", "hsl(210 10% 85%)", "hsl(355 85% 55%)"],
     heroGradient:
       "linear-gradient(135deg, hsla(212,100%,45%,0.8) 0%, hsla(218,50%,20%,0.9) 50%, hsla(210,10%,85%,0.35) 100%)",
     headline: "Fortune 100 ready",
@@ -257,11 +222,7 @@ codex/add-skin-selector-for-color-theme
     name: "Aurora Glass",
     description: "Polar neon glass for data-native operators.",
     cssVars: auroraGlassTokens,
-    previewColors: [
-      "hsl(195 86% 62%)",
-      "hsl(282 78% 68%)",
-      "hsl(152 72% 48%)",
-    ],
+    previewColors: ["hsl(195 86% 62%)", "hsl(282 78% 68%)", "hsl(152 72% 48%)"],
     heroGradient:
       "linear-gradient(135deg, hsla(195,86%,62%,0.8) 0%, hsla(282,78%,68%,0.7) 55%, hsla(197,56%,96%,0.35) 100%)",
     headline: "Neon telemetry",
@@ -271,11 +232,7 @@ codex/add-skin-selector-for-color-theme
     name: "Ember Vanguard",
     description: "Sunset war room with molten KPI heat.",
     cssVars: emberVanguardTokens,
-    previewColors: [
-      "hsl(16 92% 58%)",
-      "hsl(347 74% 62%)",
-      "hsl(42 86% 62%)",
-    ],
+    previewColors: ["hsl(16 92% 58%)", "hsl(347 74% 62%)", "hsl(42 86% 62%)"],
     heroGradient:
       "linear-gradient(135deg, hsla(16,92%,58%,0.85) 0%, hsla(347,74%,62%,0.75) 50%, hsla(32,40%,94%,0.35) 100%)",
     headline: "Molten conversions",
@@ -288,17 +245,8 @@ const skinMap = new Map<SkinId, SkinDefinition>(
   SKIN_DEFINITIONS.map((definition) => [definition.id, definition]),
 );
 
- codex/add-skin-selector-for-color-theme
-export const defaultSkinId: SkinId = "fortune-100";
-
-=======
- codex/add-skin-selector-for-color-theme-on40yv
-export const defaultSkinId: SkinId = "fortune-100";
-
 export const defaultSkinId: SkinId = "liquid-glass-pro";
-main
 
- main
 export function getAvailableSkins(): readonly SkinDefinition[] {
   return SKIN_DEFINITIONS;
 }

--- a/src/pages/TemplateGallery.tsx
+++ b/src/pages/TemplateGallery.tsx
@@ -1,23 +1,20 @@
-import React from 'react';
+import * as React from "react";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Separator } from '@/components/ui/separator';
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-=======
-codex/find-email-templates-for-dental-and-precare-coverage-dftp26
- main
-import { CheckCircle2, Copy, FileText, MessageCircleMore, Sparkles } from 'lucide-react';
-import { CoverageTemplate, topDentalTemplates } from '@/data/dentalTemplates';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { RcsTemplate, spotlightPetcareRcsTemplates } from '@/data/petcareRcsTemplates';
+  CheckCircle2,
+  Copy,
+  FileText,
+  MessageCircleMore,
+  Sparkles,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CoverageTemplate, topDentalTemplates } from "@/data/dentalTemplates";
+import { RcsTemplate, spotlightPetcareRcsTemplates } from "@/data/petcareRcsTemplates";
 
 const HeroHeading = () => (
   <div className="flex flex-col gap-4 rounded-2xl border border-corporate-blue/40 bg-corporate-navy/20 p-8 shadow-xl backdrop-blur">
@@ -28,12 +25,19 @@ const HeroHeading = () => (
     <div className="flex flex-col gap-3">
       <h1 className="text-4xl font-semibold text-white drop-shadow">Petcare Coverage Template Deck</h1>
       <p className="max-w-3xl text-base text-corporate-silver">
-        Toggle between Twilio SendGrid emails and Twilio RCS rich cards. Each tile distills persona targeting, CTA strategy, dynamic field mapping, and payload guidance you can trigger from Supabase and mirror in your Rust desktop copilots.
- codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-=======
-=======
-import { CheckCircle2, Copy, FileText, Sparkles } from 'lucide-react';
-import { CoverageTemplate, topDentalTemplates } from '@/data/dentalTemplates';
+        Toggle between Twilio SendGrid emails and Twilio RCS rich cards. Each tile distills persona targeting,
+        CTA strategy, dynamic field mapping, and payload guidance ready to sync with Supabase workflows and your Rust
+        desktop copilots.
+      </p>
+    </div>
+    <div className="flex flex-wrap gap-3">
+      <Badge className="bg-corporate-blue/80 text-white">Liquid glass UI preview</Badge>
+      <Badge className="bg-revenue-green/80 text-corporate-charcoal">Supabase metadata ready</Badge>
+      <Badge className="bg-corporate-crimson/70 text-white">Twilio SendGrid compliant</Badge>
+      <Badge className="bg-amber-500/70 text-corporate-charcoal">Twilio RCS optimized</Badge>
+    </div>
+  </div>
+);
 
 const SectionHeading = () => (
   <div className="flex flex-col gap-4 rounded-2xl border border-corporate-blue/40 bg-corporate-navy/20 p-8 shadow-xl backdrop-blur">
@@ -42,34 +46,19 @@ const SectionHeading = () => (
       <span className="text-sm uppercase tracking-[0.3em]">Twilio Ready Email Ops</span>
     </div>
     <div className="flex flex-col gap-3">
-      <h1 className="text-4xl font-semibold text-white drop-shadow">Dental Coverage Template Deck</h1>
+      <h2 className="text-3xl font-semibold text-white drop-shadow">Dental Coverage Template Deck</h2>
       <p className="max-w-3xl text-base text-corporate-silver">
-        Visualize the top ten templates from the 50-email library. Each tile distills persona targeting, CTA strategy, dynamic field mapping, and the exact HTML payload you can sync into Twilio SendGrid via your Supabase-powered automation flows.
-main
-main
+        Visualize the top ten templates from the 50-email library. Each tile distills persona targeting, CTA strategy,
+        dynamic field mapping, and the exact HTML payload you can sync into Twilio SendGrid via your Supabase-powered
+        automation flows.
       </p>
-    </div>
-    <div className="flex flex-wrap gap-3">
-      <Badge className="bg-corporate-blue/80 text-white">Liquid glass UI preview</Badge>
-      <Badge className="bg-revenue-green/80 text-corporate-charcoal">Supabase metadata ready</Badge>
- codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-      <Badge className="bg-corporate-crimson/70 text-white">Twilio SendGrid compliant</Badge>
-      <Badge className="bg-amber-500/70 text-corporate-charcoal">Twilio RCS optimized</Badge>
-=======
-codex/find-email-templates-for-dental-and-precare-coverage-dftp26
-      <Badge className="bg-corporate-crimson/70 text-white">Twilio SendGrid compliant</Badge>
-      <Badge className="bg-amber-500/70 text-corporate-charcoal">Twilio RCS optimized</Badge>
-=======
-      <Badge className="bg-corporate-crimson/70 text-white">Twilio template compliant</Badge>
- main
-main
     </div>
   </div>
 );
 
 type CopyTarget = {
   id: string;
-  type: 'subject' | 'body';
+  type: "subject" | "body" | "rcs";
 };
 
 const TemplateCard = ({ template }: { template: CoverageTemplate }) => {
@@ -77,19 +66,19 @@ const TemplateCard = ({ template }: { template: CoverageTemplate }) => {
 
   React.useEffect(() => {
     if (!copied) return;
-    if (typeof window === 'undefined') return;
+    if (typeof window === "undefined") return;
     const timer = window.setTimeout(() => setCopied(null), 2400);
     return () => window.clearTimeout(timer);
   }, [copied]);
 
-  const handleCopy = async (value: string, type: CopyTarget['type']) => {
+  const handleCopy = async (value: string, type: CopyTarget["type"]) => {
     try {
-      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(value);
         setCopied({ id: template.id, type });
       }
     } catch (error) {
-      console.error('Unable to copy template content', error);
+      console.error("Unable to copy template content", error);
       setCopied(null);
     }
   };
@@ -101,11 +90,9 @@ const TemplateCard = ({ template }: { template: CoverageTemplate }) => {
         <div className="flex items-start justify-between gap-3">
           <div>
             <CardTitle className="text-2xl text-corporate-platinum">
-              {template.category} {template.id.split('-')[1]} — {template.title}
+              {template.category} {template.id.split("-")[1]} — {template.title}
             </CardTitle>
-            <CardDescription className="text-sm text-corporate-silver">
-              Persona: {template.persona}
-            </CardDescription>
+            <CardDescription className="text-sm text-corporate-silver">Persona: {template.persona}</CardDescription>
           </div>
           <Badge className="bg-corporate-navy/80 text-xs uppercase tracking-wide text-corporate-platinum">
             {template.cta}
@@ -113,12 +100,10 @@ const TemplateCard = ({ template }: { template: CoverageTemplate }) => {
         </div>
         <div className="grid gap-2 text-sm text-corporate-platinum">
           <div>
-            <span className="font-semibold text-revenue-green">Subject:</span>{' '}
-            <span>{template.subject}</span>
+            <span className="font-semibold text-revenue-green">Subject:</span> <span>{template.subject}</span>
           </div>
           <div className="text-corporate-silver">
-            <span className="font-semibold text-corporate-platinum">Preview:</span>{' '}
-            {template.preview}
+            <span className="font-semibold text-corporate-platinum">Preview:</span> {template.preview}
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -138,10 +123,10 @@ const TemplateCard = ({ template }: { template: CoverageTemplate }) => {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => handleCopy(template.subject, 'subject')}
+            onClick={() => handleCopy(template.subject, "subject")}
             className="border-corporate-blue/60 bg-background/40 text-corporate-platinum hover:bg-corporate-blue/10"
           >
-            {copied?.id === template.id && copied?.type === 'subject' ? (
+            {copied?.id === template.id && copied?.type === "subject" ? (
               <>
                 <CheckCircle2 className="mr-2 h-4 w-4 text-revenue-green" /> Copied subject
               </>
@@ -154,10 +139,10 @@ const TemplateCard = ({ template }: { template: CoverageTemplate }) => {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => handleCopy(template.bodyHtml, 'body')}
+            onClick={() => handleCopy(template.bodyHtml, "body")}
             className="border-corporate-blue/60 bg-background/40 text-corporate-platinum hover:bg-corporate-blue/10"
           >
-            {copied?.id === template.id && copied?.type === 'body' ? (
+            {copied?.id === template.id && copied?.type === "body" ? (
               <>
                 <CheckCircle2 className="mr-2 h-4 w-4 text-revenue-green" /> Copied HTML
               </>
@@ -174,7 +159,7 @@ const TemplateCard = ({ template }: { template: CoverageTemplate }) => {
         <Separator className="bg-corporate-blue/20" />
         <ScrollArea className="h-64 w-full rounded-xl border border-corporate-blue/30 bg-corporate-navy/10 p-4 text-sm text-corporate-platinum">
           <div className="font-mono leading-relaxed">
-            {template.bodyHtml.split('\n').map((line, index) => (
+            {template.bodyHtml.split("\n").map((line, index) => (
               <div key={`${template.id}-line-${index}`}>{line}</div>
             ))}
           </div>
@@ -184,194 +169,107 @@ const TemplateCard = ({ template }: { template: CoverageTemplate }) => {
   );
 };
 
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-=======
-codex/find-email-templates-for-dental-and-precare-coverage-dftp26
- main
-const renderActionLabel = (action: RcsTemplate['suggestedActions'][number]) => {
-  switch (action.type) {
-    case 'openUrl':
-      return (
-        <div className="flex flex-col">
-          <span className="text-corporate-platinum">{action.label}</span>
-          <span className="text-xs text-corporate-silver">URL: {action.url}</span>
-        </div>
-      );
-    case 'dialerAction':
-      return (
-        <div className="flex flex-col">
-          <span className="text-corporate-platinum">{action.label}</span>
-          <span className="text-xs text-corporate-silver">Dial: {action.phoneNumber}</span>
-        </div>
-      );
-    case 'postback':
-      return (
-        <div className="flex flex-col">
-          <span className="text-corporate-platinum">{action.label}</span>
-          <span className="text-xs text-corporate-silver">Payload: {action.data}</span>
-        </div>
-      );
-    default:
-      return null;
-  }
-};
+const RcsTemplateCard = ({ template }: { template: RcsTemplate }) => {
+  const [copied, setCopied] = React.useState(false);
 
-const RcsTemplateCard = ({ template }: { template: RcsTemplate }) => (
-  <Card className="relative overflow-hidden border-corporate-blue/40 bg-background/60 shadow-lg backdrop-blur">
-    <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-amber-400 via-corporate-blue to-revenue-green opacity-70" />
-    <CardHeader className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="space-y-1">
-          <CardTitle className="text-2xl text-corporate-platinum">
-            {template.category} {template.id.split('-')[2]} — {template.title}
-          </CardTitle>
-          <CardDescription className="text-sm text-corporate-silver">Persona: {template.persona}</CardDescription>
-          <CardDescription className="text-sm text-corporate-silver">Scenario: {template.scenario}</CardDescription>
-        </div>
-        <Badge className="bg-amber-500/80 text-xs uppercase tracking-wide text-corporate-charcoal">
-          RCS rich card
-        </Badge>
-      </div>
-      <div className="text-sm text-corporate-platinum">
-        <span className="font-semibold text-revenue-green">Primary Message:</span>
-        <ScrollArea className="mt-3 h-28 rounded-lg border border-corporate-blue/30 bg-corporate-navy/20 p-3 text-sm text-corporate-platinum">
-          {template.primaryMessage}
-        </ScrollArea>
-      </div>
-      {template.media ? (
-        <div className="rounded-xl border border-corporate-blue/30 bg-corporate-navy/10 p-4 text-xs text-corporate-silver">
-          <div className="flex items-center gap-2 text-corporate-platinum">
-            <MessageCircleMore className="h-4 w-4 text-amber-400" /> Media guidance
+  React.useEffect(() => {
+    if (!copied || typeof window === "undefined") return;
+    const timeout = window.setTimeout(() => setCopied(false), 2400);
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(JSON.stringify(template.payload, null, 2));
+        setCopied(true);
+      }
+    } catch (error) {
+      console.error("Failed to copy RCS payload", error);
+      setCopied(false);
+    }
+  };
+
+  return (
+    <Card className="relative overflow-hidden border-corporate-blue/30 bg-background/60 shadow-lg backdrop-blur">
+      <CardHeader className="space-y-3">
+        <div className="flex items-start justify-between">
+          <div>
+            <CardTitle className="text-2xl text-corporate-platinum">{template.title}</CardTitle>
+            <CardDescription className="text-sm text-corporate-silver">
+              Persona: {template.persona} · CTA: {template.cta}
+            </CardDescription>
           </div>
-          <div className="mt-2 grid gap-1">
-            <span>
-              Type: <span className="text-corporate-platinum">{template.media.type}</span>
-            </span>
-            <span>
-              URL placeholder: <span className="text-corporate-platinum">{template.media.url}</span>
-            </span>
-            <span>
-              Alt: <span className="text-corporate-platinum">{template.media.alt}</span>
-            </span>
-          </div>
+          <Badge className="bg-revenue-green/20 text-revenue-green">RCS</Badge>
         </div>
-      ) : null}
-      <div className="grid gap-2">
-        <span className="text-sm font-semibold text-revenue-green">Suggested actions</span>
-        <div className="grid gap-2">
-          {template.suggestedActions.map((action, index) => (
-            <div
-              key={`${template.id}-action-${index}`}
-              className="flex items-start gap-3 rounded-xl border border-corporate-blue/30 bg-corporate-navy/10 p-3"
-            >
-              <Badge className="bg-corporate-blue/70 text-xs uppercase text-white">{action.type}</Badge>
-              {renderActionLabel(action)}
-            </div>
+        <div className="flex flex-wrap gap-2 text-xs text-corporate-silver">
+          {template.dynamicFields.map((field) => (
+            <Badge key={field} variant="outline" className="border-corporate-blue/60 bg-corporate-navy/30">
+              {`{{${field}}}`}
+            </Badge>
           ))}
         </div>
-      </div>
-      <div className="text-sm text-corporate-silver">
-        <span className="font-semibold text-corporate-platinum">Fallback SMS:</span> {template.fallbackSms}
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {template.dynamicFields.map((field) => (
-          <Badge
-            key={field}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-2 text-sm text-corporate-silver/80">
+          <MessageCircleMore className="h-4 w-4 text-corporate-platinum" /> {template.preview}
+        </div>
+        <div className="flex items-center gap-3">
+          <Button
             variant="outline"
-            className="border-corporate-blue/60 bg-corporate-navy/40 text-xs text-corporate-platinum"
+            size="sm"
+            onClick={handleCopy}
+            className="border-corporate-blue/60 bg-background/40 text-corporate-platinum hover:bg-corporate-blue/10"
           >
-            {`{{${field}}}`}
-          </Badge>
-        ))}
-      </div>
-    </CardHeader>
-    <CardContent className="space-y-4 text-sm text-corporate-silver">
-      <Separator className="bg-corporate-blue/20" />
-      <div>
-        <span className="font-semibold text-corporate-platinum">Twilio delivery notes:</span>
-        <p className="mt-1 leading-relaxed">{template.twilioNotes}</p>
-      </div>
-    </CardContent>
-  </Card>
-);
+            {copied ? (
+              <>
+                <CheckCircle2 className="mr-2 h-4 w-4 text-revenue-green" /> Copied JSON
+              </>
+            ) : (
+              <>
+                <Copy className="mr-2 h-4 w-4" /> Copy JSON
+              </>
+            )}
+          </Button>
+          <div className="rounded-full border border-corporate-blue/40 bg-corporate-navy/30 px-4 py-2 text-xs text-corporate-silver">
+            <Sparkles className="mr-2 inline h-4 w-4 text-primary" /> Suggested actions ready
+          </div>
+        </div>
+        <ScrollArea className="h-64 w-full rounded-xl border border-corporate-blue/30 bg-corporate-navy/10 p-4 text-sm text-corporate-platinum">
+          <pre className="whitespace-pre-wrap font-mono text-xs leading-relaxed">
+            {JSON.stringify(template.payload, null, 2)}
+          </pre>
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  );
+};
 
 const TemplateGallery = () => {
   return (
     <div className="space-y-10">
       <HeroHeading />
       <Tabs defaultValue="email" className="space-y-8">
-        <TabsList className="w-full justify-start gap-3 rounded-2xl border border-corporate-blue/40 bg-corporate-navy/30 p-2">
-          <TabsTrigger
-            value="email"
-            className="rounded-xl px-4 py-2 text-sm text-corporate-platinum transition data-[state=active]:bg-corporate-blue/60 data-[state=active]:text-white"
-          >
-            Email templates
-          </TabsTrigger>
-          <TabsTrigger
-            value="rcs"
-            className="rounded-xl px-4 py-2 text-sm text-corporate-platinum transition data-[state=active]:bg-amber-400/80 data-[state=active]:text-corporate-charcoal"
-          >
-            RCS templates
-          </TabsTrigger>
+        <TabsList className="grid w-full grid-cols-2 rounded-2xl bg-white/5 p-1">
+          <TabsTrigger value="email">Email templates</TabsTrigger>
+          <TabsTrigger value="rcs">RCS templates</TabsTrigger>
         </TabsList>
         <TabsContent value="email" className="space-y-6">
-          <div className="grid gap-6 xl:grid-cols-2">
+          <SectionHeading />
+          <div className="grid gap-6">
             {topDentalTemplates.map((template) => (
               <TemplateCard key={template.id} template={template} />
             ))}
           </div>
-          <div className="rounded-2xl border border-corporate-blue/40 bg-corporate-navy/10 p-6 text-sm text-corporate-platinum">
-            Need the full 50-template playbook? Sync the markdown from{' '}
-            <a
-              href="/docs/email-templates/dental-precare-templates"
-              className="font-semibold text-revenue-green underline-offset-4 hover:underline"
-            >
-              docs/email-templates/dental-precare-templates.md
-            </a>{' '}
-            into your Supabase storage bucket or marketing knowledge base for complete access.
-          </div>
         </TabsContent>
         <TabsContent value="rcs" className="space-y-6">
-          <div className="grid gap-6 xl:grid-cols-2">
+          <div className="grid gap-6">
             {spotlightPetcareRcsTemplates.map((template) => (
               <RcsTemplateCard key={template.id} template={template} />
             ))}
           </div>
-          <div className="rounded-2xl border border-corporate-blue/40 bg-corporate-navy/10 p-6 text-sm text-corporate-platinum">
-            Need the complete RCS playbook with 20 scripts? Mirror{' '}
-            <a
-              href="/docs/rcs-templates/petcare-rcs-templates"
-              className="font-semibold text-amber-300 underline-offset-4 hover:underline"
-            >
-              docs/rcs-templates/petcare-rcs-templates.md
-            </a>{' '}
-            inside Supabase storage or your internal enablement wiki.
-          </div>
         </TabsContent>
       </Tabs>
-codex/find-email-templates-for-dental-and-precare-coverage-bku57i
-=======
-const TemplateGallery = () => {
-  return (
-    <div className="space-y-10">
-      <SectionHeading />
-      <div className="grid gap-6 xl:grid-cols-2">
-        {topDentalTemplates.map((template) => (
-          <TemplateCard key={template.id} template={template} />
-        ))}
-      </div>
-      <div className="rounded-2xl border border-corporate-blue/40 bg-corporate-navy/10 p-6 text-sm text-corporate-platinum">
-        Need the full 50-template playbook? Sync the markdown from{' '}
-        <a
-          href="/docs/email-templates/dental-precare-templates"
-          className="font-semibold text-revenue-green underline-offset-4 hover:underline"
-        >
-          docs/email-templates/dental-precare-templates.md
-        </a>{' '}
-        into your Supabase storage bucket or marketing knowledge base for complete access.
-      </div>
-main
- main
     </div>
   );
 };

--- a/supabase/migrations/20241015090000_lead_ingestion_tables.sql
+++ b/supabase/migrations/20241015090000_lead_ingestion_tables.sql
@@ -1,0 +1,122 @@
+-- Lead ingestion pipeline tables powering CSV/XLSX uploads
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'lead_ingestion_status') THEN
+        CREATE TYPE public.lead_ingestion_status AS ENUM ('processing', 'succeeded', 'failed', 'cancelled');
+    END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS public.lead_ingestions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    filename text NOT NULL,
+    status public.lead_ingestion_status NOT NULL DEFAULT 'processing',
+    total_rows bigint,
+    processed_rows bigint NOT NULL DEFAULT 0,
+    error text,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    completed_at timestamptz,
+    CONSTRAINT lead_ingestions_progress_check CHECK (
+        processed_rows >= 0
+        AND (total_rows IS NULL OR total_rows >= 0)
+        AND (total_rows IS NULL OR processed_rows <= total_rows)
+    )
+);
+
+COMMENT ON TABLE public.lead_ingestions IS 'Metadata for each batch ingestion initiated from the Lead Intelligence dashboard.';
+COMMENT ON COLUMN public.lead_ingestions.filename IS 'Original filename provided by the operator.';
+COMMENT ON COLUMN public.lead_ingestions.status IS 'Lifecycle marker for ingestion processing state.';
+COMMENT ON COLUMN public.lead_ingestions.total_rows IS 'Expected total rows detected in the uploaded dataset.';
+COMMENT ON COLUMN public.lead_ingestions.processed_rows IS 'Rows successfully written to the leads table.';
+COMMENT ON COLUMN public.lead_ingestions.metadata IS 'Arbitrary metadata captured during ingestion (column stats, sampling, etc).';
+
+CREATE TABLE IF NOT EXISTS public.leads (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    ingestion_id uuid REFERENCES public.lead_ingestions(id) ON DELETE SET NULL,
+    source_filename text,
+    first_name text,
+    last_name text,
+    email text,
+    phone text,
+    company text,
+    hashed_phone text,
+    raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now())
+);
+
+COMMENT ON TABLE public.leads IS 'Raw lead records landed from CSV/XLSX uploads and API pushes.';
+COMMENT ON COLUMN public.leads.ingestion_id IS 'Foreign key to the originating lead_ingestions row.';
+COMMENT ON COLUMN public.leads.source_filename IS 'Convenience reference back to the uploaded file name.';
+COMMENT ON COLUMN public.leads.raw_payload IS 'Original sanitized row payload for downstream processing.';
+COMMENT ON COLUMN public.leads.hashed_phone IS 'SHA-256 hash of the numeric phone value for dedupe without exposing PII.';
+
+CREATE INDEX IF NOT EXISTS idx_lead_ingestions_status ON public.lead_ingestions(status);
+CREATE INDEX IF NOT EXISTS idx_lead_ingestions_updated_at ON public.lead_ingestions(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_leads_ingestion_id ON public.leads(ingestion_id);
+CREATE INDEX IF NOT EXISTS idx_leads_created_at ON public.leads(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_leads_email ON public.leads(lower(email)) WHERE email IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_leads_hashed_phone ON public.leads(hashed_phone) WHERE hashed_phone IS NOT NULL;
+
+ALTER TABLE public.lead_ingestions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.leads ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "allow authenticated read lead_ingestions" ON public.lead_ingestions;
+CREATE POLICY "allow authenticated read lead_ingestions"
+    ON public.lead_ingestions
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+DROP POLICY IF EXISTS "allow authenticated write lead_ingestions" ON public.lead_ingestions;
+CREATE POLICY "allow authenticated write lead_ingestions"
+    ON public.lead_ingestions
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (true);
+
+DROP POLICY IF EXISTS "allow authenticated update lead_ingestions" ON public.lead_ingestions;
+CREATE POLICY "allow authenticated update lead_ingestions"
+    ON public.lead_ingestions
+    FOR UPDATE
+    TO authenticated
+    USING (true)
+    WITH CHECK (true);
+
+DROP POLICY IF EXISTS "service role manage lead_ingestions" ON public.lead_ingestions;
+CREATE POLICY "service role manage lead_ingestions"
+    ON public.lead_ingestions
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+DROP POLICY IF EXISTS "allow authenticated read leads" ON public.leads;
+CREATE POLICY "allow authenticated read leads"
+    ON public.leads
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+DROP POLICY IF EXISTS "allow authenticated insert leads" ON public.leads;
+CREATE POLICY "allow authenticated insert leads"
+    ON public.leads
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (true);
+
+DROP POLICY IF EXISTS "service role manage leads" ON public.leads;
+CREATE POLICY "service role manage leads"
+    ON public.leads
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+DROP TRIGGER IF EXISTS trg_touch_lead_ingestions ON public.lead_ingestions;
+CREATE TRIGGER trg_touch_lead_ingestions
+    BEFORE UPDATE ON public.lead_ingestions
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_updated_at();
+


### PR DESCRIPTION
## Summary
- restore the main app router, sidebar navigation, and skin selector backed by Supabase preferences
- rebuild the financial data hook and dashboard tabs with resilient Supabase fallbacks and refreshed visualizations
- refresh the template gallery and shared UI primitives for reliable clipboard actions and command palette usage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e00313dc748328ba5bf93d81930085